### PR TITLE
Fix location activity type retrieval in SettingsManager

### DIFF
--- a/miataru/miataru/SettingsManagers/App Settings/SettingsManager.swift
+++ b/miataru/miataru/SettingsManagers/App Settings/SettingsManager.swift
@@ -86,7 +86,7 @@ class SettingsManager: ObservableObject {
         self.mapUpdateInterval = Int(d.string(forKey: Keys.mapUpdateInterval) ?? "30") ?? 30
         self.mapZoomLevel = Int(d.string(forKey: Keys.mapZoomLevel) ?? "1") ?? 1
         self.historyNumberOfDays = Int(d.string(forKey: Keys.historyNumberOfDays) ?? "10000000") ?? 10000000
-        self.locationActivityType = Int(d.string(forKey: Keys.locationActivityType) ?? "0") ?? 0
+        self.locationActivityType = d.object(forKey: Keys.locationActivityType) as? Int ?? 0
         self.locationSensitivityLevel = d.object(forKey: Keys.locationSensitivityLevel) as? Int ?? 2
         self.autoRefreshDeviceList = d.object(forKey: Keys.autoRefreshDeviceList) as? Bool ?? true
     }


### PR DESCRIPTION
## Summary
- read `locationActivityType` from UserDefaults as `Int`

## Testing
- `swift test` (fails: Could not find Package.swift)
- `xcodebuild test -scheme miataru -destination 'platform=iOS Simulator,name=iPhone 14'` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a6e952465883238ac257df2b28d67d