### PR TITLE
Add reverse geocoded location names to device list

### DIFF
--- a/miataru/miataru/SettingsManagers/App Settings/Devices/DeviceLocationCacheStore.swift
+++ b/miataru/miataru/SettingsManagers/App Settings/Devices/DeviceLocationCacheStore.swift
@@ -10,6 +10,7 @@
 import Foundation
 import UIKit
 import Combine
+import CoreLocation
 
 @objc(CachedDeviceLocation)
 class CachedDeviceLocation: NSObject, NSCoding, NSSecureCoding, Identifiable {
@@ -18,15 +19,19 @@ class CachedDeviceLocation: NSObject, NSCoding, NSSecureCoding, Identifiable {
     @objc var longitude: Double
     @objc var accuracy: Double
     @objc var timestamp: Date
+    @objc var country: String?
+    @objc var locality: String?
     
     var id: String { deviceID }
     
-    init(deviceID: String, latitude: Double, longitude: Double, accuracy: Double, timestamp: Date) {
+    init(deviceID: String, latitude: Double, longitude: Double, accuracy: Double, timestamp: Date, country: String? = nil, locality: String? = nil) {
         self.deviceID = deviceID
         self.latitude = latitude
         self.longitude = longitude
         self.accuracy = accuracy
         self.timestamp = timestamp
+        self.country = country
+        self.locality = locality
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -35,6 +40,8 @@ class CachedDeviceLocation: NSObject, NSCoding, NSSecureCoding, Identifiable {
         self.longitude = aDecoder.decodeDouble(forKey: "longitude")
         self.accuracy = aDecoder.decodeDouble(forKey: "accuracy")
         self.timestamp = aDecoder.decodeObject(forKey: "timestamp") as? Date ?? Date()
+        self.country = aDecoder.decodeObject(forKey: "country") as? String
+        self.locality = aDecoder.decodeObject(forKey: "locality") as? String
     }
     
     func encode(with aCoder: NSCoder) {
@@ -43,6 +50,8 @@ class CachedDeviceLocation: NSObject, NSCoding, NSSecureCoding, Identifiable {
         aCoder.encode(longitude, forKey: "longitude")
         aCoder.encode(accuracy, forKey: "accuracy")
         aCoder.encode(timestamp, forKey: "timestamp")
+        aCoder.encode(country, forKey: "country")
+        aCoder.encode(locality, forKey: "locality")
     }
     
     static var supportsSecureCoding: Bool {
@@ -81,10 +90,10 @@ class DeviceLocationCacheStore: ObservableObject {
             let data = try NSKeyedArchiver.archivedData(withRootObject: locations, requiringSecureCoding: true)
             try data.write(to: fileURL)
         } catch {
-            debugLog("Fehler beim Speichern der DeviceLocations: \(error)")
+            debugLog("Error saving device locations: \(error)")
         }
     }
-    
+
     private func load() -> [CachedDeviceLocation] {
         guard let data = try? Data(contentsOf: fileURL) else { return [] }
         do {
@@ -92,21 +101,55 @@ class DeviceLocationCacheStore: ObservableObject {
                 return locations
             }
         } catch {
-            debugLog("Fehler beim Laden der DeviceLocations: \(error)")
+            debugLog("Error loading device locations: \(error)")
+            // Remove incompatible cache file to prevent repeated load failures
+            try? FileManager.default.removeItem(at: fileURL)
         }
         return []
     }
-    
+
     func setLocation(for deviceID: String, latitude: Double, longitude: Double, accuracy: Double, timestamp: Date) {
         if let idx = locations.firstIndex(where: { $0.deviceID == deviceID }) {
-            locations[idx] = CachedDeviceLocation(deviceID: deviceID, latitude: latitude, longitude: longitude, accuracy: accuracy, timestamp: timestamp)
+            let existing = locations[idx]
+            let moved = existing.latitude != latitude || existing.longitude != longitude
+            let updated = CachedDeviceLocation(
+                deviceID: deviceID,
+                latitude: latitude,
+                longitude: longitude,
+                accuracy: accuracy,
+                timestamp: timestamp,
+                country: moved ? nil : existing.country,
+                locality: moved ? nil : existing.locality
+            )
+            locations[idx] = updated
         } else {
             locations.append(CachedDeviceLocation(deviceID: deviceID, latitude: latitude, longitude: longitude, accuracy: accuracy, timestamp: timestamp))
         }
     }
-    
+
     func getLocation(for deviceID: String) -> CachedDeviceLocation? {
         return locations.first(where: { $0.deviceID == deviceID })
+    }
+
+    func getPlacemark(for deviceID: String) -> (country: String?, locality: String?)? {
+        guard let loc = locations.first(where: { $0.deviceID == deviceID }) else { return nil }
+        return (loc.country, loc.locality)
+    }
+
+    func setPlacemark(for deviceID: String, country: String?, locality: String?) {
+        if let idx = locations.firstIndex(where: { $0.deviceID == deviceID }) {
+            let loc = locations[idx]
+            let updated = CachedDeviceLocation(
+                deviceID: loc.deviceID,
+                latitude: loc.latitude,
+                longitude: loc.longitude,
+                accuracy: loc.accuracy,
+                timestamp: loc.timestamp,
+                country: country,
+                locality: locality
+            )
+            locations[idx] = updated
+        }
     }
     
     func removeLocation(for deviceID: String) {

--- a/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceRowView.swift
+++ b/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceRowView.swift
@@ -16,7 +16,8 @@ import MapKit // For CLLocationCoordinate2D
 
 struct iPhone_DeviceRowView: View {
     @ObservedObject var device: KnownDevice
-    @ObservedObject var cache: DeviceLocationCacheStore // <-- hinzugefügt
+    @ObservedObject var cache: DeviceLocationCacheStore
+    @State private var isGeocoding = false
     // For live updates, you could use @ObservedObject for the cache, but for now, fetch on render
     
     var body: some View {
@@ -32,6 +33,11 @@ struct iPhone_DeviceRowView: View {
                 // Subtitle: last seen + distance
                 if let subtitle = subtitleText() {
                     Text(subtitle)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                if let place = placemarkText() {
+                    Text(place)
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -55,7 +61,7 @@ struct iPhone_DeviceRowView: View {
         let now = Date()
         let relativeTime = relativeTimeString(from: cached.timestamp, to: now, unitsStyle: .abbreviated)
         // Distance calculation
-        guard let myCached = cache.getLocation(for: thisDeviceIDManager.shared.deviceID) else { // <-- cache statt .shared
+        guard let myCached = cache.getLocation(for: thisDeviceIDManager.shared.deviceID) else {
             let lastSeen = NSLocalizedString("device_row_last_seen", comment: "Label for the last seen time of a device in the device list row")
             return "\(lastSeen): \(relativeTime)"
         }
@@ -93,6 +99,29 @@ struct iPhone_DeviceRowView: View {
         let distanceLabel = NSLocalizedString("device_row_distance", comment: "Label for the distance to the device in the device list row")
         return "\(lastSeen): \(relativeTime) \(separator) \(distanceLabel): \(formattedDistance)"
     }
+
+    private func placemarkText() -> String? {
+        guard let cached = cache.getLocation(for: device.DeviceID) else { return nil }
+        if let placemark = cache.getPlacemark(for: device.DeviceID), let country = placemark.country, let locality = placemark.locality {
+            return "\(locality), \(country)"
+        } else {
+            if !isGeocoding {
+                isGeocoding = true
+                let location = CLLocation(latitude: cached.latitude, longitude: cached.longitude)
+                CLGeocoder().reverseGeocodeLocation(location) { placemarks, _ in
+                    defer { isGeocoding = false }
+                    if let pm = placemarks?.first {
+                        let country = pm.country
+                        let locality = pm.locality ?? pm.subAdministrativeArea ?? pm.administrativeArea
+                        DispatchQueue.main.async {
+                            cache.setPlacemark(for: device.DeviceID, country: country, locality: locality)
+                        }
+                    }
+                }
+            }
+            return nil
+        }
+    }
 }
 
 extension Color {
@@ -124,7 +153,7 @@ extension Color {
 // }
 
 #Preview {
-    @Previewable @State var device = KnownDevice(name: "Testgerät", deviceID: "12345", color: .blue)
-    iPhone_DeviceRowView(device: device, cache: DeviceLocationCacheStore.shared) // <-- cache übergeben
-} 
+    @Previewable @State var device = KnownDevice(name: "Test Device", deviceID: "12345", color: .blue)
+    iPhone_DeviceRowView(device: device, cache: DeviceLocationCacheStore.shared)
+}
 


### PR DESCRIPTION
## Summary
- cache country and city in `DeviceLocationCacheStore`
- reverse geocode device coordinates and show `City, Country` in each device row
- discard incompatible cache files if the stored format is outdated
- translate comments and debug output to English

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a6a198c883238320a95bae14b917