### PR TITLE
Add navigation routing between devices

### DIFF
--- a/miataru/miataru/SettingsManagers/App Settings/SettingsManager.swift
+++ b/miataru/miataru/SettingsManagers/App Settings/SettingsManager.swift
@@ -65,6 +65,9 @@ class SettingsManager: ObservableObject {
     @Published var showOffscreenArrowsForOtherDevices: Bool {
         didSet { defaults.set(showOffscreenArrowsForOtherDevices, forKey: Keys.showOffscreenArrowsForOtherDevices) }
     }
+    @Published var navigationTransportType: Int {
+        didSet { defaults.set(navigationTransportType, forKey: Keys.navigationTransportType) }
+    }
     
     // MARK: - Keys
     private enum Keys {
@@ -82,6 +85,7 @@ class SettingsManager: ObservableObject {
         static let locationSensitivityLevel = "location_sensitivity_level"
         static let autoRefreshDeviceList = "auto_refresh_device_list"
         static let showOffscreenArrowsForOtherDevices = "show_offscreen_arrows_for_other_devices"
+        static let navigationTransportType = "navigation_transport_type"
     }
     
     // MARK: - Location Permission Management
@@ -108,6 +112,7 @@ class SettingsManager: ObservableObject {
         self.locationSensitivityLevel = Int(d.string(forKey: Keys.locationSensitivityLevel) ?? "2") ?? 2
         self.autoRefreshDeviceList = d.object(forKey: Keys.autoRefreshDeviceList) as? Bool ?? true
         self.showOffscreenArrowsForOtherDevices = d.object(forKey: Keys.showOffscreenArrowsForOtherDevices) as? Bool ?? false
+        self.navigationTransportType = Int(d.string(forKey: Keys.navigationTransportType) ?? "2") ?? 2
     }
     
     // MARK: - Synchronize

--- a/miataru/miataru/views/Common/DeviceNavigationView.swift
+++ b/miataru/miataru/views/Common/DeviceNavigationView.swift
@@ -1,0 +1,170 @@
+/*
+ * DeviceNavigationView.swift
+ * miataru
+ *
+ * Displays route between the user's device and a selected device.
+ */
+
+import SwiftUI
+import MapKit
+
+struct DeviceNavigationView: View {
+    var device: KnownDevice
+
+    @ObservedObject private var cache = DeviceLocationCacheStore.shared
+    @ObservedObject private var locationManager = LocationManager.shared
+    @ObservedObject private var settings = SettingsManager.shared
+
+    @Namespace private var mapScope
+    @State private var userCoordinate: CLLocationCoordinate2D?
+    @State private var deviceCoordinate: CLLocationCoordinate2D?
+    @State private var animatedUserCoordinate: CLLocationCoordinate2D?
+    @State private var animatedDeviceCoordinate: CLLocationCoordinate2D?
+    @State private var route: MKRoute?
+    @State private var mapPosition: MapCameraPosition = .automatic
+    @State private var travelTime: String?
+    @State private var currentRegion: MKCoordinateRegion?
+    @State private var hasSetInitialRegion = false
+    @State private var userHasInteractedWithMap = false
+
+    var body: some View {
+        VStack {
+            Map(position: $mapPosition, scope: mapScope) {
+                if let coord = animatedUserCoordinate {
+                    Annotation("me", coordinate: coord) {
+                        MiataruMapMarker(color: .blue)
+                    }
+                }
+                if let coord = animatedDeviceCoordinate {
+                    Annotation(device.DeviceName, coordinate: coord) {
+                        MiataruMapMarker(color: Color(device.DeviceColor ?? .red))
+                    }
+                }
+                if let polyline = route?.polyline {
+                    MapPolyline(polyline)
+                        .stroke(.blue, lineWidth: 4)
+                }
+            }
+            .ignoresSafeArea()
+            .onMapCameraChange { context in
+                currentRegion = context.region
+                if context.reason == .userInteraction {
+                    userHasInteractedWithMap = true
+                }
+            }
+            .onAppear {
+                updateCoordinates(recenter: true)
+                calculateRoute()
+            }
+            .onReceive(locationManager.$currentLocation) { _ in
+                updateCoordinates()
+            }
+            .onReceive(cache.$locations) { _ in
+                updateCoordinates()
+            }
+            .overlay(alignment: .top) {
+                if let travelTime {
+                    Text(travelTime)
+                        .padding(8)
+                        .background(.thinMaterial)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .padding()
+                }
+            }
+
+            HStack {
+                Button(action: {
+                    updateCoordinates(recenter: true)
+                    calculateRoute()
+                }) {
+                    Label("reload_route", systemImage: "arrow.clockwise")
+                }
+                Spacer()
+                Button(action: openInAppleMaps) {
+                    Label("open_in_apple_maps", systemImage: "arrow.up.right.square")
+                }
+            }
+            .padding()
+        }
+    }
+
+    private func updateCoordinates(recenter: Bool = false) {
+        if let loc = locationManager.currentLocation {
+            let coord = loc.coordinate
+            let changed = userCoordinate?.latitude != coord.latitude || userCoordinate?.longitude != coord.longitude
+            userCoordinate = coord
+            if changed || animatedUserCoordinate == nil {
+                withAnimation { animatedUserCoordinate = coord }
+            }
+        }
+        if let cached = cache.getLocation(for: device.DeviceID) {
+            let coord = CLLocationCoordinate2D(latitude: cached.latitude, longitude: cached.longitude)
+            let changed = deviceCoordinate?.latitude != coord.latitude || deviceCoordinate?.longitude != coord.longitude
+            deviceCoordinate = coord
+            if changed || animatedDeviceCoordinate == nil {
+                withAnimation { animatedDeviceCoordinate = coord }
+            }
+        }
+        if let user = userCoordinate, let dest = deviceCoordinate,
+           (!hasSetInitialRegion || recenter || !userHasInteractedWithMap) {
+            let region = regionThatFits(user: user, dest: dest)
+            withAnimation {
+                mapPosition = .region(region)
+            }
+            hasSetInitialRegion = true
+        }
+    }
+
+    private func regionThatFits(user: CLLocationCoordinate2D, dest: CLLocationCoordinate2D) -> MKCoordinateRegion {
+        let center = CLLocationCoordinate2D(latitude: (user.latitude + dest.latitude) / 2,
+                                            longitude: (user.longitude + dest.longitude) / 2)
+        let span = MKCoordinateSpan(latitudeDelta: abs(user.latitude - dest.latitude) * 2.5,
+                                    longitudeDelta: abs(user.longitude - dest.longitude) * 2.5)
+        return MKCoordinateRegion(center: center, span: span)
+    }
+
+    private func calculateRoute() {
+        guard let user = userCoordinate, let dest = deviceCoordinate else { return }
+        let request = MKDirections.Request()
+        request.source = MKMapItem(placemark: MKPlacemark(coordinate: user))
+        request.destination = MKMapItem(placemark: MKPlacemark(coordinate: dest))
+        request.transportType = transportTypeFromSetting(settings.navigationTransportType)
+        Task {
+            do {
+                let response = try await MKDirections(request: request).calculate()
+                if let first = response.routes.first {
+                    route = first
+                    let formatter = DateComponentsFormatter()
+                    formatter.unitsStyle = .short
+                    travelTime = formatter.string(from: first.expectedTravelTime)
+                }
+            } catch {
+                debugLog("Route calculation failed: \(error)")
+            }
+        }
+    }
+
+    private func openInAppleMaps() {
+        guard let user = userCoordinate, let dest = deviceCoordinate else { return }
+        let source = MKMapItem(placemark: MKPlacemark(coordinate: user))
+        let destination = MKMapItem(placemark: MKPlacemark(coordinate: dest))
+        var options: [String: Any] = [:]
+        switch settings.navigationTransportType {
+        case 0: options[MKLaunchOptionsDirectionsModeKey] = MKLaunchOptionsDirectionsModeWalking
+        case 1: options[MKLaunchOptionsDirectionsModeKey] = MKLaunchOptionsDirectionsModeDefault
+        case 3: options[MKLaunchOptionsDirectionsModeKey] = MKLaunchOptionsDirectionsModeTransit
+        default: options[MKLaunchOptionsDirectionsModeKey] = MKLaunchOptionsDirectionsModeDriving
+        }
+        MKMapItem.openMaps(with: [source, destination], launchOptions: options)
+    }
+
+    private func transportTypeFromSetting(_ value: Int) -> MKDirectionsTransportType {
+        switch value {
+        case 0: return .walking
+        case 1: return .any
+        case 3: return .transit
+        default: return .automobile
+        }
+    }
+}
+

--- a/miataru/miataru/views/iPad/Devices Views/iPad_DeviceMapView.swift
+++ b/miataru/miataru/views/iPad/Devices Views/iPad_DeviceMapView.swift
@@ -50,6 +50,7 @@ struct iPad_DeviceMapView: View {
     @State private var userHasRotatedMap = false // Tracks if user manually rotated the map
     @StateObject private var errorOverlayManager = ErrorOverlayManager() // Manages error overlay
     @State private var showEditDeviceSheet = false // Controls device edit sheet
+    @State private var showNavigationSheet = false // Controls navigation view
     @State private var now = Date() // Timer for relative time display
     private let timeUpdateTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect() // Timer for updating 'now'
     @State private var showNetworkErrorIcon = false // Show network error icon on network issues
@@ -278,6 +279,11 @@ struct iPad_DeviceMapView: View {
                 iPhone_EditDeviceView(device: $deviceStore.devices[index], isPresented: $showEditDeviceSheet)
             }
         }
+        .sheet(isPresented: $showNavigationSheet) {
+            if let device = device {
+                DeviceNavigationView(device: device)
+            }
+        }
     }
     
     // MARK: - View Components
@@ -409,6 +415,11 @@ struct iPad_DeviceMapView: View {
                                         .contextMenu {
                                             Button("edit_device") {
                                                 showEditDeviceSheet = true
+                                            }
+                                            Button {
+                                                showNavigationSheet = true
+                                            } label: {
+                                                Label("navigation", systemImage: "location").labelStyle(.titleAndIcon)
                                             }
                                         }
                             }

--- a/miataru/miataru/views/iPad/Groups Views/iPad_GroupMapView.swift
+++ b/miataru/miataru/views/iPad/Groups Views/iPad_GroupMapView.swift
@@ -44,6 +44,8 @@ struct iPad_GroupMapView: View {
     private let timeUpdateTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     @State private var editingDeviceID: String? = nil // State for the device being edited
     @State private var showEditDeviceSheet: Bool = false // Sheet trigger for editing device
+    @State private var navigationDeviceID: String? = nil // Device for navigation
+    @State private var showNavigationSheet: Bool = false // Navigation sheet trigger
     @State private var showNetworkErrorIcon = false // Show network error icon
     @State private var screenSize: CGSize = .zero // Track screen size for off-screen arrows
     
@@ -354,6 +356,11 @@ struct iPad_GroupMapView: View {
                 iPhone_EditDeviceView(device: $deviceStore.devices[index], isPresented: $showEditDeviceSheet)
             }
         }
+        .sheet(isPresented: $showNavigationSheet) {
+            if let deviceID = navigationDeviceID, let device = deviceStore.devices.first(where: { $0.DeviceID == deviceID }) {
+                DeviceNavigationView(device: device)
+            }
+        }
     }
     
     @ViewBuilder
@@ -423,6 +430,12 @@ struct iPad_GroupMapView: View {
                                         showEditDeviceSheet = true
                                     } label: {
                                         Label("edit_device", systemImage: "pencil").labelStyle(.titleAndIcon)
+                                    }
+                                    Button {
+                                        navigationDeviceID = deviceID
+                                        showNavigationSheet = true
+                                    } label: {
+                                        Label("navigation", systemImage: "location").labelStyle(.titleAndIcon)
                                     }
                                 }
                         }.offset(y: 10)

--- a/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceMapView.swift
+++ b/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceMapView.swift
@@ -50,6 +50,7 @@ struct iPhone_DeviceMapView: View {
     @State private var userHasRotatedMap = false // Tracks if user manually rotated the map
     @StateObject private var errorOverlayManager = ErrorOverlayManager() // Manages error overlay
     @State private var showEditDeviceSheet = false // Controls device edit sheet
+    @State private var showNavigationSheet = false // Controls navigation view
     @State private var now = Date() // Timer for relative time display
     private let timeUpdateTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect() // Timer for updating 'now'
     @State private var showNetworkErrorIcon = false // Show network error icon on network issues
@@ -276,6 +277,11 @@ struct iPhone_DeviceMapView: View {
                 iPhone_EditDeviceView(device: $deviceStore.devices[index], isPresented: $showEditDeviceSheet)
             }
         }
+        .sheet(isPresented: $showNavigationSheet) {
+            if let device = device {
+                DeviceNavigationView(device: device)
+            }
+        }
     }
     
     // MARK: - View Components
@@ -409,6 +415,11 @@ struct iPhone_DeviceMapView: View {
                                         showEditDeviceSheet = true
                                     } label: {
                                         Label("edit_device", systemImage: "pencil")
+                                    }
+                                    Button {
+                                        showNavigationSheet = true
+                                    } label: {
+                                        Label("navigation", systemImage: "location")
                                     }
                                 }
                         }.offset(y:10)

--- a/miataru/miataru/views/iPhone/Groups Views/iPhone_GroupMapView.swift
+++ b/miataru/miataru/views/iPhone/Groups Views/iPhone_GroupMapView.swift
@@ -43,6 +43,8 @@ struct iPhone_GroupMapView: View {
     private let timeUpdateTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     @State private var editingDeviceID: String? = nil // State for the device being edited
     @State private var showEditDeviceSheet: Bool = false // Sheet trigger for editing device
+    @State private var navigationDeviceID: String? = nil // Device ID for navigation
+    @State private var showNavigationSheet: Bool = false // Sheet trigger for navigation
     @State private var showNetworkErrorIcon = false // Show network error icon
     @State private var screenSize: CGSize = .zero // Track screen size for off-screen arrows
     
@@ -346,6 +348,11 @@ struct iPhone_GroupMapView: View {
                 iPhone_EditDeviceView(device: $deviceStore.devices[index], isPresented: $showEditDeviceSheet)
             }
         }
+        .sheet(isPresented: $showNavigationSheet) {
+            if let deviceID = navigationDeviceID, let device = deviceStore.devices.first(where: { $0.DeviceID == deviceID }) {
+                DeviceNavigationView(device: device)
+            }
+        }
     }
     
     @ViewBuilder
@@ -415,6 +422,12 @@ struct iPhone_GroupMapView: View {
                                         showEditDeviceSheet = true
                                     } label: {
                                         Label("edit_device", systemImage: "pencil")
+                                    }
+                                    Button {
+                                        navigationDeviceID = deviceID
+                                        showNavigationSheet = true
+                                    } label: {
+                                        Label("navigation", systemImage: "location")
                                     }
                                 }
                         }.offset(y: 10)

--- a/miataru/miataru/views/iPhone/Settings Views/iPhone_SettingsView.swift
+++ b/miataru/miataru/views/iPhone/Settings Views/iPhone_SettingsView.swift
@@ -140,6 +140,14 @@ struct iPhone_SettingsView: View {
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
+                Section(header: Text("navigation")) {
+                    Picker("transport_mode", selection: $settings.navigationTransportType) {
+                        Text("transport_walk").tag(0)
+                        Text("transport_bike").tag(1)
+                        Text("transport_car").tag(2)
+                        Text("transport_transit").tag(3)
+                    }
+                }
                 // Location Tracking Status Section
                 Section(header: Text("Location Tracking Status")) {
                     HStack {


### PR DESCRIPTION
## Summary
- add transport mode setting
- enable navigation action on map markers
- show routing between devices with reload and Apple Maps options
- keep navigation pins in sync with updated device locations

## Testing
- `swift --version`
- `xcodebuild -list` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a907f4d88323a8081641c43e7e11