### PR TITLE
Group off-screen device arrows by edge

### DIFF
--- a/miataru/miataru/views/Common/OffscreenDeviceEdgeHelper.swift
+++ b/miataru/miataru/views/Common/OffscreenDeviceEdgeHelper.swift
@@ -1,0 +1,78 @@
+import MapKit
+
+/// Helper to determine on which screen edge an off-screen coordinate lies.
+/// Returns `nil` if the coordinate is inside the current screen region.
+struct OffscreenDeviceEdgeHelper {
+    static func edge(for coordinate: CLLocationCoordinate2D,
+                     in region: MKCoordinateRegion,
+                     screenSize: CGSize,
+                     heading: Double) -> Edge? {
+        let center = CGPoint(x: screenSize.width / 2, y: screenSize.height / 2)
+        let pointUnrotated = coordinateToScreenPoint(coordinate,
+                                                      region: region,
+                                                      screenSize: screenSize,
+                                                      center: center)
+        let point = rotate(point: pointUnrotated, around: center, degrees: -heading)
+
+        let visibilityMargin: CGFloat = 20
+        let isOutside =
+            point.x < visibilityMargin ||
+            point.x > screenSize.width - visibilityMargin ||
+            point.y < visibilityMargin ||
+            point.y > screenSize.height - visibilityMargin
+        guard isOutside else { return nil }
+
+        let dx = point.x - center.x
+        let dy = point.y - center.y
+        let halfWidth = screenSize.width / 2
+        let halfHeight = screenSize.height / 2
+
+        if abs(dx) / halfWidth > abs(dy) / halfHeight {
+            return dx > 0 ? .right : .left
+        } else {
+            return dy > 0 ? .bottom : .top
+        }
+    }
+
+    private static func coordinateToScreenPoint(_ coordinate: CLLocationCoordinate2D,
+                                                 region: MKCoordinateRegion,
+                                                 screenSize: CGSize,
+                                                 center: CGPoint) -> CGPoint {
+        let latDelta = max(region.span.latitudeDelta, 1e-9)
+        let lonDelta = max(region.span.longitudeDelta, 1e-9)
+
+        let dLon = deltaLongitude(coordinate.longitude, region.center.longitude)
+        let dLat = coordinate.latitude - region.center.latitude
+
+        let xRatio = CGFloat(dLon / lonDelta).clamped(to: -4...4)
+        let yRatio = CGFloat(dLat / latDelta).clamped(to: -4...4)
+
+        let x = center.x + xRatio * screenSize.width
+        let y = center.y - yRatio * screenSize.height
+        return CGPoint(x: x, y: y)
+    }
+
+    private static func rotate(point: CGPoint, around center: CGPoint, degrees: Double) -> CGPoint {
+        let radians = degrees * .pi / 180
+        let translatedX = point.x - center.x
+        let translatedY = point.y - center.y
+        let cosA = cos(radians)
+        let sinA = sin(radians)
+        let x = translatedX * cosA - translatedY * sinA + center.x
+        let y = translatedX * sinA + translatedY * cosA + center.y
+        return CGPoint(x: x, y: y)
+    }
+
+    private static func deltaLongitude(_ lon: CLLocationDegrees, _ center: CLLocationDegrees) -> CLLocationDegrees {
+        var d = lon - center
+        if d > 180 { d -= 360 }
+        if d < -180 { d += 360 }
+        return d
+    }
+}
+
+private extension Comparable {
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        return min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/miataru/miataru/views/iPad/Devices Views/iPad_DeviceMapView.swift
+++ b/miataru/miataru/views/iPad/Devices Views/iPad_DeviceMapView.swift
@@ -117,62 +117,68 @@ struct iPad_DeviceMapView: View {
             // Network error icon (top left)
             networkErrorIconView()
             
-            // Off-screen device arrows for all known devices (only shown when map is not rotated)
+            // Off-screen device arrows grouped by screen edge (only shown when map is not rotated)
             if !screenSize.width.isZero && !screenSize.height.isZero,
                let region = currentRegion ?? cameraPosition.region {
-                // Show arrow for the current device
-                if let device = device,
-                   let coordinate = deviceLocation {
-                    OffScreenDeviceArrow(
-                        deviceName: device.DeviceName.isEmpty ? device.DeviceID : device.DeviceName,
-                        deviceColor: Color(device.DeviceColor ?? UIColor.blue),
-                        screenCenter: CGPoint(x: screenSize.width / 2, y: screenSize.height / 2),
-                        deviceCoordinate: coordinate,
-                        mapRegion: region,
-                        screenSize: screenSize,
-                        isMapRotated: false,
-                        mapHeading: currentMapCamera?.heading ?? 0,
-                        arrowIndex: 0,
-                        totalArrows: 1,
-                        behavior: .jumpToLocation,
-                        onTap: {
-                            // Animate to device location
-                            withAnimation(.easeInOut(duration: 0.8)) {
-                                if #available(iOS 17.0, *) {
-                                    if let currentRegion = cameraPosition.region {
-                                        cameraPosition = .region(MKCoordinateRegion(center: coordinate, span: currentRegion.span))
-                                    }
-                                } else {
-                                    // Fallback for older iOS versions
-                                    self.region = MKCoordinateRegion(center: coordinate, span: self.region.span)
+
+                typealias ArrowData = (device: KnownDevice, coordinate: CLLocationCoordinate2D, behavior: ArrowBehavior, onTap: () -> Void)
+                var devicesByEdge: [Edge: [ArrowData]] = [:]
+
+                // Current device
+                if let device = device, let coordinate = deviceLocation,
+                   let edge = OffscreenDeviceEdgeHelper.edge(for: coordinate,
+                                                            in: region,
+                                                            screenSize: screenSize,
+                                                            heading: currentMapCamera?.heading ?? 0) {
+                    let tap = {
+                        withAnimation(.easeInOut(duration: 0.8)) {
+                            if #available(iOS 17.0, *) {
+                                if let currentRegion = cameraPosition.region {
+                                    cameraPosition = .region(MKCoordinateRegion(center: coordinate, span: currentRegion.span))
                                 }
+                            } else {
+                                self.region = MKCoordinateRegion(center: coordinate, span: self.region.span)
                             }
                         }
-                    )
+                    }
+                    devicesByEdge[edge, default: []].append((device, coordinate, .jumpToLocation, tap))
                 }
-                
-                // Show arrows for other known devices that are outside the visible area (only if setting is enabled)
+
+                // Other devices
                 if settings.showOffscreenArrowsForOtherDevices {
-                    let offscreenDevices = deviceStore.devices.filter { $0.DeviceID != deviceID }
-                    ForEach(Array(offscreenDevices.enumerated()), id: \.element.DeviceID) { index, otherDevice in
+                    let otherDevices = deviceStore.devices.filter { $0.DeviceID != deviceID }
+                    for otherDevice in otherDevices {
                         if let cached = cache.getLocation(for: otherDevice.DeviceID) {
                             let coordinate = CLLocationCoordinate2D(latitude: cached.latitude, longitude: cached.longitude)
+                            if let edge = OffscreenDeviceEdgeHelper.edge(for: coordinate,
+                                                                         in: region,
+                                                                         screenSize: screenSize,
+                                                                         heading: currentMapCamera?.heading ?? 0) {
+                                let tap = { onNavigateToDevice?(otherDevice.DeviceID) }
+                                devicesByEdge[edge, default: []].append((otherDevice, coordinate, .navigateToDevice, tap))
+                            }
+                        }
+                    }
+                }
+
+                // Render arrows grouped by edge
+                let screenCenter = CGPoint(x: screenSize.width / 2, y: screenSize.height / 2)
+                ForEach([Edge.left, .right, .top, .bottom], id: \.self) { edge in
+                    if let group = devicesByEdge[edge] {
+                        ForEach(Array(group.enumerated()), id: \.element.device.DeviceID) { index, info in
                             OffScreenDeviceArrow(
-                                deviceName: otherDevice.DeviceName.isEmpty ? otherDevice.DeviceID : otherDevice.DeviceName,
-                                deviceColor: Color(otherDevice.DeviceColor ?? UIColor.blue),
-                                screenCenter: CGPoint(x: screenSize.width / 2, y: screenSize.height / 2),
-                                deviceCoordinate: coordinate,
+                                deviceName: info.device.DeviceName.isEmpty ? info.device.DeviceID : info.device.DeviceName,
+                                deviceColor: Color(info.device.DeviceColor ?? UIColor.blue),
+                                screenCenter: screenCenter,
+                                deviceCoordinate: info.coordinate,
                                 mapRegion: region,
                                 screenSize: screenSize,
                                 isMapRotated: false,
                                 mapHeading: currentMapCamera?.heading ?? 0,
                                 arrowIndex: index,
-                                totalArrows: offscreenDevices.count,
-                                behavior: .navigateToDevice,
-                                onTap: {
-                                    // Navigate to device detail view
-                                    onNavigateToDevice?(otherDevice.DeviceID)
-                                }
+                                totalArrows: group.count,
+                                behavior: info.behavior,
+                                onTap: info.onTap
                             )
                         }
                     }

--- a/miataru/miataru/views/iPad/Groups Views/iPad_GroupMapView.swift
+++ b/miataru/miataru/views/iPad/Groups Views/iPad_GroupMapView.swift
@@ -90,37 +90,56 @@ struct iPad_GroupMapView: View {
     // Helper view for off-screen device arrows to avoid complex expressions in body
     @ViewBuilder
     private func offscreenDeviceArrowsView() -> some View {
-        ForEach(Array(groupDeviceIDs.enumerated()), id: \.element) { index, deviceID in
-            if let device = deviceStore.devices.first(where: { $0.DeviceID == deviceID }),
-               let coordinate = deviceLocations[deviceID],
-               let region = currentRegion ?? cameraPosition.region {
-                OffScreenDeviceArrow(
-                    deviceName: device.DeviceName.isEmpty ? device.DeviceID : device.DeviceName,
-                    deviceColor: Color(device.DeviceColor ?? UIColor.blue),
-                    screenCenter: CGPoint(x: screenSize.width / 2, y: screenSize.height / 2),
-                    deviceCoordinate: coordinate,
-                    mapRegion: region,
-                    screenSize: screenSize,
-                    isMapRotated: false,
-                    mapHeading: currentMapCamera?.heading ?? 0,
-                    arrowIndex: index,
-                    totalArrows: groupDeviceIDs.count,
-                    behavior: .jumpToLocation,
-                    onTap: {
-                        // Animate to device location
+        var devicesByEdge: [Edge: [(device: KnownDevice, coordinate: CLLocationCoordinate2D, onTap: () -> Void)]] = [:]
+
+        if let region = currentRegion ?? cameraPosition.region {
+            for deviceID in groupDeviceIDs {
+                if let device = deviceStore.devices.first(where: { $0.DeviceID == deviceID }),
+                   let coordinate = deviceLocations[deviceID],
+                   let edge = OffscreenDeviceEdgeHelper.edge(for: coordinate,
+                                                            in: region,
+                                                            screenSize: screenSize,
+                                                            heading: currentMapCamera?.heading ?? 0) {
+                    let tap = {
                         withAnimation(.easeInOut(duration: 0.8)) {
                             if #available(iOS 17.0, *) {
                                 if let currentRegion = cameraPosition.region {
                                     cameraPosition = .region(MKCoordinateRegion(center: coordinate, span: currentRegion.span))
                                 }
                             } else {
-                                // Fallback for older iOS versions
                                 self.region = MKCoordinateRegion(center: coordinate, span: self.region.span)
                             }
                         }
                     }
-                )
+                    devicesByEdge[edge, default: []].append((device, coordinate, tap))
+                }
             }
+
+            let screenCenter = CGPoint(x: screenSize.width / 2, y: screenSize.height / 2)
+            return AnyView(
+                ForEach([Edge.left, .right, .top, .bottom], id: \.self) { edge in
+                    if let group = devicesByEdge[edge] {
+                        ForEach(Array(group.enumerated()), id: \.element.device.DeviceID) { index, info in
+                            OffScreenDeviceArrow(
+                                deviceName: info.device.DeviceName.isEmpty ? info.device.DeviceID : info.device.DeviceName,
+                                deviceColor: Color(info.device.DeviceColor ?? UIColor.blue),
+                                screenCenter: screenCenter,
+                                deviceCoordinate: info.coordinate,
+                                mapRegion: region,
+                                screenSize: screenSize,
+                                isMapRotated: false,
+                                mapHeading: currentMapCamera?.heading ?? 0,
+                                arrowIndex: index,
+                                totalArrows: group.count,
+                                behavior: .jumpToLocation,
+                                onTap: info.onTap
+                            )
+                        }
+                    }
+                }
+            )
+        } else {
+            return AnyView(EmptyView())
         }
     }
     

--- a/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceMapView.swift
+++ b/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceMapView.swift
@@ -117,62 +117,68 @@ struct iPhone_DeviceMapView: View {
             // Network error icon (top left)
             networkErrorIconView()
             
-            // Off-screen device arrows for all known devices (only shown when map is not rotated)
+            // Off-screen device arrows grouped by screen edge (only shown when map is not rotated)
             if !screenSize.width.isZero && !screenSize.height.isZero,
                let region = currentRegion ?? cameraPosition.region {
-                // Show arrow for the current device
-                if let device = device,
-                   let coordinate = deviceLocation {
-                    OffScreenDeviceArrow(
-                        deviceName: device.DeviceName.isEmpty ? device.DeviceID : device.DeviceName,
-                        deviceColor: Color(device.DeviceColor ?? UIColor.blue),
-                        screenCenter: CGPoint(x: screenSize.width / 2, y: screenSize.height / 2),
-                        deviceCoordinate: coordinate,
-                        mapRegion: region,
-                        screenSize: screenSize,
-                        isMapRotated: false,
-                        mapHeading: currentMapCamera?.heading ?? 0,
-                        arrowIndex: 0,
-                        totalArrows: 1,
-                        behavior: .jumpToLocation,
-                        onTap: {
-                            // Animate to device location
-                            withAnimation(.easeInOut(duration: 0.8)) {
-                                if #available(iOS 17.0, *) {
-                                    if let currentRegion = cameraPosition.region {
-                                        cameraPosition = .region(MKCoordinateRegion(center: coordinate, span: currentRegion.span))
-                                    }
-                                } else {
-                                    // Fallback for older iOS versions
-                                    self.region = MKCoordinateRegion(center: coordinate, span: self.region.span)
+
+                typealias ArrowData = (device: KnownDevice, coordinate: CLLocationCoordinate2D, behavior: ArrowBehavior, onTap: () -> Void)
+                var devicesByEdge: [Edge: [ArrowData]] = [:]
+
+                // Current device
+                if let device = device, let coordinate = deviceLocation,
+                   let edge = OffscreenDeviceEdgeHelper.edge(for: coordinate,
+                                                            in: region,
+                                                            screenSize: screenSize,
+                                                            heading: currentMapCamera?.heading ?? 0) {
+                    let tap = {
+                        withAnimation(.easeInOut(duration: 0.8)) {
+                            if #available(iOS 17.0, *) {
+                                if let currentRegion = cameraPosition.region {
+                                    cameraPosition = .region(MKCoordinateRegion(center: coordinate, span: currentRegion.span))
                                 }
+                            } else {
+                                self.region = MKCoordinateRegion(center: coordinate, span: self.region.span)
                             }
                         }
-                    )
+                    }
+                    devicesByEdge[edge, default: []].append((device, coordinate, .jumpToLocation, tap))
                 }
-                
-                // Show arrows for other known devices that are outside the visible area (only if setting is enabled)
+
+                // Other devices
                 if settings.showOffscreenArrowsForOtherDevices {
-                    let offscreenDevices = deviceStore.devices.filter { $0.DeviceID != deviceID }
-                    ForEach(Array(offscreenDevices.enumerated()), id: \.element.DeviceID) { index, otherDevice in
+                    let otherDevices = deviceStore.devices.filter { $0.DeviceID != deviceID }
+                    for otherDevice in otherDevices {
                         if let cached = cache.getLocation(for: otherDevice.DeviceID) {
                             let coordinate = CLLocationCoordinate2D(latitude: cached.latitude, longitude: cached.longitude)
+                            if let edge = OffscreenDeviceEdgeHelper.edge(for: coordinate,
+                                                                         in: region,
+                                                                         screenSize: screenSize,
+                                                                         heading: currentMapCamera?.heading ?? 0) {
+                                let tap = { onNavigateToDevice?(otherDevice.DeviceID) }
+                                devicesByEdge[edge, default: []].append((otherDevice, coordinate, .navigateToDevice, tap))
+                            }
+                        }
+                    }
+                }
+
+                // Render arrows grouped by edge
+                let screenCenter = CGPoint(x: screenSize.width / 2, y: screenSize.height / 2)
+                ForEach([Edge.left, .right, .top, .bottom], id: \.self) { edge in
+                    if let group = devicesByEdge[edge] {
+                        ForEach(Array(group.enumerated()), id: \.element.device.DeviceID) { index, info in
                             OffScreenDeviceArrow(
-                                deviceName: otherDevice.DeviceName.isEmpty ? otherDevice.DeviceID : otherDevice.DeviceName,
-                                deviceColor: Color(otherDevice.DeviceColor ?? UIColor.blue),
-                                screenCenter: CGPoint(x: screenSize.width / 2, y: screenSize.height / 2),
-                                deviceCoordinate: coordinate,
+                                deviceName: info.device.DeviceName.isEmpty ? info.device.DeviceID : info.device.DeviceName,
+                                deviceColor: Color(info.device.DeviceColor ?? UIColor.blue),
+                                screenCenter: screenCenter,
+                                deviceCoordinate: info.coordinate,
                                 mapRegion: region,
                                 screenSize: screenSize,
                                 isMapRotated: false,
                                 mapHeading: currentMapCamera?.heading ?? 0,
                                 arrowIndex: index,
-                                totalArrows: offscreenDevices.count,
-                                behavior: .navigateToDevice,
-                                                                                        onTap: {
-                                    // Navigate to device detail view
-                                    onNavigateToDevice?(otherDevice.DeviceID)
-                                }
+                                totalArrows: group.count,
+                                behavior: info.behavior,
+                                onTap: info.onTap
                             )
                         }
                     }

--- a/miataru/miataru/views/iPhone/Groups Views/iPhone_GroupMapView.swift
+++ b/miataru/miataru/views/iPhone/Groups Views/iPhone_GroupMapView.swift
@@ -89,37 +89,56 @@ struct iPhone_GroupMapView: View {
     // Helper view for off-screen device arrows to avoid complex expressions in body
     @ViewBuilder
     private func offscreenDeviceArrowsView() -> some View {
-        ForEach(Array(groupDeviceIDs.enumerated()), id: \.element) { index, deviceID in
-            if let device = deviceStore.devices.first(where: { $0.DeviceID == deviceID }),
-               let coordinate = deviceLocations[deviceID],
-               let region = currentRegion ?? cameraPosition.region {
-                OffScreenDeviceArrow(
-                    deviceName: device.DeviceName.isEmpty ? device.DeviceID : device.DeviceName,
-                    deviceColor: Color(device.DeviceColor ?? UIColor.blue),
-                    screenCenter: CGPoint(x: screenSize.width / 2, y: screenSize.height / 2),
-                    deviceCoordinate: coordinate,
-                    mapRegion: region,
-                    screenSize: screenSize,
-                    isMapRotated: false,
-                    mapHeading: currentMapCamera?.heading ?? 0,
-                    arrowIndex: index,
-                    totalArrows: groupDeviceIDs.count,
-                    behavior: .jumpToLocation,
-                    onTap: {
-                        // Animate to device location
+        var devicesByEdge: [Edge: [(device: KnownDevice, coordinate: CLLocationCoordinate2D, onTap: () -> Void)]] = [:]
+
+        if let region = currentRegion ?? cameraPosition.region {
+            for deviceID in groupDeviceIDs {
+                if let device = deviceStore.devices.first(where: { $0.DeviceID == deviceID }),
+                   let coordinate = deviceLocations[deviceID],
+                   let edge = OffscreenDeviceEdgeHelper.edge(for: coordinate,
+                                                            in: region,
+                                                            screenSize: screenSize,
+                                                            heading: currentMapCamera?.heading ?? 0) {
+                    let tap = {
                         withAnimation(.easeInOut(duration: 0.8)) {
                             if #available(iOS 17.0, *) {
                                 if let currentRegion = cameraPosition.region {
                                     cameraPosition = .region(MKCoordinateRegion(center: coordinate, span: currentRegion.span))
                                 }
                             } else {
-                                // Fallback for older iOS versions
                                 self.region = MKCoordinateRegion(center: coordinate, span: self.region.span)
                             }
                         }
                     }
-                )
+                    devicesByEdge[edge, default: []].append((device, coordinate, tap))
+                }
             }
+
+            let screenCenter = CGPoint(x: screenSize.width / 2, y: screenSize.height / 2)
+            return AnyView(
+                ForEach([Edge.left, .right, .top, .bottom], id: \.self) { edge in
+                    if let group = devicesByEdge[edge] {
+                        ForEach(Array(group.enumerated()), id: \.element.device.DeviceID) { index, info in
+                            OffScreenDeviceArrow(
+                                deviceName: info.device.DeviceName.isEmpty ? info.device.DeviceID : info.device.DeviceName,
+                                deviceColor: Color(info.device.DeviceColor ?? UIColor.blue),
+                                screenCenter: screenCenter,
+                                deviceCoordinate: info.coordinate,
+                                mapRegion: region,
+                                screenSize: screenSize,
+                                isMapRotated: false,
+                                mapHeading: currentMapCamera?.heading ?? 0,
+                                arrowIndex: index,
+                                totalArrows: group.count,
+                                behavior: .jumpToLocation,
+                                onTap: info.onTap
+                            )
+                        }
+                    }
+                }
+            )
+        } else {
+            return AnyView(EmptyView())
         }
     }
     


### PR DESCRIPTION
## Summary
- group off-screen devices per screen edge and distribute arrows accordingly
- centralize edge calculation in new `OffscreenDeviceEdgeHelper`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ac57aca3848323925012f9564736e8