### PR TITLE
Ensure mail composer loads with QR image

### DIFF
--- a/miataru/miataru/views/iPhone/iPhone_MyDeviceQRCodeView.swift
+++ b/miataru/miataru/views/iPhone/iPhone_MyDeviceQRCodeView.swift
@@ -184,10 +184,11 @@ struct iPhone_MyDeviceQRCodeView: View {
                 }
             }
         )
-        .sheet(isPresented: $showMailComposer) {
-            if let qrImage = qrImage {
-                MailView(deviceID: thisDeviceIDManager.shared.deviceID, qrImage: qrImage)
-            }
+        .sheet(isPresented: $showMailComposer, onDismiss: { qrImage = nil }) {
+            MailView(
+                deviceID: thisDeviceIDManager.shared.deviceID,
+                qrImage: qrImage ?? (generateQRCodeImage() ?? UIImage())
+            )
         }
         .sheet(isPresented: $showShareFallback) {
             let items: [Any] = {


### PR DESCRIPTION
## Summary
- Prevent blank sheet by always supplying MailView with a generated QR image
- Clear cached QR image when the mail composer is dismissed

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8634019c8323810e57aead44ee86