### PR TITLE
Add shared menu commands for opening device windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [User Experience and Flow](#user-experience-and-flow)
 - [Migration from Earlier Versions](#migration-from-earlier-versions)
 - [Error Handling and Battery Optimization](#error-handling-and-battery-optimization)
+- [Menu Commands on iPad and Mac](#menu-commands-on-ipad-and-mac)
 - [License](#license)
 
 ---
@@ -96,6 +97,15 @@ The app is organized into several key components:
   - The app can disable device auto-lock if requested, but defaults to energy-saving behavior.
   - Background activity is minimized unless explicitly enabled in settings.
   - Observers ensure that tracking and background tasks are only active when necessary.
+
+---
+
+## Menu Commands on iPad and Mac
+
+Miataru uses SwiftUI's `Commands` API to expose additional menu items on platforms that support multiwindow interfaces.
+
+- **iPad**: Attach a hardware keyboard or use the system's menu bar (from the three-dot "more" menu) to access **Window → New Device Window**, which opens a new device window.
+- **Mac**: The same command is available in the Window menu and opens an additional device window using the app's native `openWindow` support.
 
 ---
 

--- a/miataru/miataru/Commands/MiataruMenuCommands.swift
+++ b/miataru/miataru/Commands/MiataruMenuCommands.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct MiataruMenuCommands: Commands {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some Commands {
+        CommandGroup(after: .windowArrangement) {
+            Button("New Device Window") {
+                openWindow(id: "deviceWindow")
+            }
+        }
+    }
+}

--- a/miataru/miataru/miataruApp.swift
+++ b/miataru/miataru/miataruApp.swift
@@ -97,8 +97,11 @@ struct miataruApp: App {
                 break
             }
         }
-        WindowGroup(for: String.self) { deviceID in
-            if let deviceID = deviceID.wrappedValue {
+        .commands {
+            MiataruMenuCommands()
+        }
+        WindowGroup(id: "deviceWindow", for: String.self) { deviceID in
+            if let deviceID = deviceID.wrappedValue, !deviceID.isEmpty {
                 iPad_DeviceMapView(deviceID: deviceID)
             } else {
                 Text(NSLocalizedString("no_device_selected", comment: "No device selected for this window."))


### PR DESCRIPTION
## Summary
- add `MiataruMenuCommands` with "New Device Window" command using `openWindow`
- expose the commands across targets and identify device windows via `deviceWindow`
- document how to access menu commands on iPad and Mac

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b00f64c6948323bac41150898cc7ab