### PR TITLE
Add group action handler and group menu commands for iPad

### DIFF
--- a/miataru/miataru/GroupActionHandler.swift
+++ b/miataru/miataru/GroupActionHandler.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Handles group related actions that might be triggered globally
+/// through menu commands or other UI components. Designed to be
+/// platform agnostic so it can be reused for a future Mac port.
+@MainActor
+class GroupActionHandler: ObservableObject {
+    /// Controls presentation of the add-group sheet.
+    @Published var showAddGroup: Bool = false
+    /// Holds the group currently being edited.
+    @Published var editingGroup: DeviceGroup? = nil
+    /// Represents the group that is currently selected/visible in the UI.
+    @Published var currentGroup: DeviceGroup? = nil
+
+    /// Trigger display of the add group sheet.
+    func addGroup() {
+        showAddGroup = true
+    }
+
+    /// Trigger editing of the currently selected group.
+    func editCurrentGroup() {
+        editingGroup = currentGroup
+    }
+}
+

--- a/miataru/miataru/MiataruMenuCommands.swift
+++ b/miataru/miataru/MiataruMenuCommands.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct MiataruMenuCommands: Commands {
+    @EnvironmentObject private var groupActionHandler: GroupActionHandler
+
+    var body: some Commands {
+        #if os(iOS)
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            groupMenu
+        } else {
+            EmptyCommands()
+        }
+        #else
+        groupMenu
+        #endif
+    }
+
+    private var groupMenu: some Commands {
+        CommandMenu(NSLocalizedString("groups", comment: "Menu title for groups")) {
+            Button(NSLocalizedString("add_group", comment: "Add group")) {
+                groupActionHandler.showAddGroup = true
+            }
+            .keyboardShortcut("G", modifiers: [.command, .shift])
+
+            Button(NSLocalizedString("edit_selected_group", comment: "Edit selected group")) {
+                groupActionHandler.editingGroup = groupActionHandler.currentGroup
+            }
+            .disabled(groupActionHandler.currentGroup == nil)
+        }
+    }
+}
+

--- a/miataru/miataru/miataruApp.swift
+++ b/miataru/miataru/miataruApp.swift
@@ -25,6 +25,7 @@ class AppState: ObservableObject {
 struct miataruApp: App {
     @Environment(\.scenePhase) private var scenePhase
     @StateObject private var appState = AppState()
+    @StateObject private var groupActionHandler = GroupActionHandler()
     @State private var autolockCancellable: AnyCancellable? = nil
     @State private var showAddDeviceSheet = false
     @State private var pendingDeviceID: String? = nil
@@ -57,6 +58,7 @@ struct miataruApp: App {
         WindowGroup {
             MiataruRootView()
                 .environmentObject(appState)
+                .environmentObject(groupActionHandler)
                 .fullScreenCover(isPresented: $appState.showOnboarding) {
                     OnboardingContainerView(isPresented: $appState.showOnboarding)
                         .background(Color(.systemBackground))
@@ -86,6 +88,10 @@ struct miataruApp: App {
                         iPhone_AddDeviceView(store: KnownDeviceStore.shared, isPresented: $showAddDeviceSheet, prefillDeviceID: deviceID)
                     }
                 }
+        }
+        .commands {
+            MiataruMenuCommands()
+                .environmentObject(groupActionHandler)
         }
         .onChange(of: scenePhase) {
             switch scenePhase {

--- a/miataru/miataru/views/iPad/iPad_GroupsView.swift
+++ b/miataru/miataru/views/iPad/iPad_GroupsView.swift
@@ -11,11 +11,9 @@ import SwiftUI
 
 struct iPad_GroupsView: View {
     @EnvironmentObject private var groupStore: DeviceGroupStore
+    @EnvironmentObject private var groupActionHandler: GroupActionHandler
     @State private var selection: String? = nil // groupID
-    @State private var showingAddGroup = false
-    @State private var editingGroup: DeviceGroup? = nil
     @State private var editMode: EditMode = .inactive
-    @State private var currentGroup: DeviceGroup? = nil // Track the currently displayed group
     @State private var lastSelectedGroupID: String? = nil // Preserve selection across edit mode toggles
 
     var body: some View {
@@ -28,7 +26,7 @@ struct iPad_GroupsView: View {
                             .tint(.primary)
                             .contextMenu {
                                 Button {
-                                    editingGroup = group
+                                    groupActionHandler.editingGroup = group
                                 } label: {
                                     Label(NSLocalizedString("edit_group", comment: "Edit this group."), systemImage: "pencil")
                                 }
@@ -40,7 +38,7 @@ struct iPad_GroupsView: View {
                             }
                             .swipeActions(edge: .leading) {
                                 Button {
-                                    editingGroup = group
+                                    groupActionHandler.editingGroup = group
                                 } label: {
                                     Label(NSLocalizedString("edit_group", comment: "Edit this group."), systemImage: "pencil")
                                 }
@@ -71,7 +69,7 @@ struct iPad_GroupsView: View {
                     }
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: { showingAddGroup = true }) {
+                    Button(action: { groupActionHandler.showAddGroup = true }) {
                         Image(systemName: "plus")
                     }
                 }
@@ -84,17 +82,17 @@ struct iPad_GroupsView: View {
                     .environmentObject(groupStore) // Pass the groupStore to the map view
                     .toolbar {
                         ToolbarItem(placement: .navigationBarTrailing) {
-                            Button(action: { editingGroup = groupStore.groups.first(where: { $0.id == selectedID }) }) {
+                            Button(action: { groupActionHandler.editingGroup = groupStore.groups.first(where: { $0.id == selectedID }) }) {
                                 Label(NSLocalizedString("edit_group", comment: "Edit the selected group.."), systemImage: "pencil")
                                     .labelStyle(.titleAndIcon)
                             }
                         }
                     }
-                    .sheet(item: $editingGroup) { group in
+                    .sheet(item: $groupActionHandler.editingGroup) { group in
                         iPad_GroupDetailView(group: group)
                     }
-                    .onChange(of: editingGroup) { _, newValue in
-                        // When the editingGroup becomes nil (sheet is dismissed), 
+                    .onChange(of: groupActionHandler.editingGroup) { _, newValue in
+                        // When the editingGroup becomes nil (sheet is dismissed),
                         // force a refresh of the map view
                         if newValue == nil {
                             // Trigger a refresh by temporarily clearing and restoring the selection
@@ -112,8 +110,8 @@ struct iPad_GroupsView: View {
                     .padding()
             }
         }
-        .sheet(isPresented: $showingAddGroup) {
-            iPhone_AddGroupView(groupStore: groupStore, isPresented: $showingAddGroup)
+        .sheet(isPresented: $groupActionHandler.showAddGroup) {
+            iPhone_AddGroupView(groupStore: groupStore, isPresented: $groupActionHandler.showAddGroup)
         }
         .onAppear {
             // Automatically select the first group if no group is currently selected
@@ -121,11 +119,19 @@ struct iPad_GroupsView: View {
                 let firstID = groupStore.groups.first?.id
                 selection = firstID
                 lastSelectedGroupID = firstID
+                if let group = groupStore.groups.first(where: { $0.id == firstID }) {
+                    groupActionHandler.currentGroup = group
+                }
             }
         }
         .onChange(of: selection) { _, newSelection in
             if let newSelection = newSelection, newSelection != lastSelectedGroupID {
                 lastSelectedGroupID = newSelection
+            }
+            if let id = newSelection, let group = groupStore.groups.first(where: { $0.id == id }) {
+                groupActionHandler.currentGroup = group
+            } else if newSelection == nil {
+                groupActionHandler.currentGroup = nil
             }
         }
         .onChange(of: editMode) { _, newMode in
@@ -140,5 +146,7 @@ struct iPad_GroupsView: View {
 }
 
 #Preview {
-    iPad_GroupsView().environmentObject(DeviceGroupStore.shared)
-} 
+    iPad_GroupsView()
+        .environmentObject(DeviceGroupStore.shared)
+        .environmentObject(GroupActionHandler())
+}


### PR DESCRIPTION
## Summary
- Introduce reusable `GroupActionHandler` to manage add and edit actions for groups
- Wire iPad group view to use the handler and keep track of the current group
- Add `MiataruMenuCommands` with “Add Group” (⌘⇧G) and “Edit Selected Group” commands, enabled on iPad

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project miataru.xcodeproj -scheme miataru -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b00f6874a48323920740b4762ccda7