### PR TITLE
Visualize interpolated device position along navigation route

### DIFF
--- a/miataru/miataru/RouteStyle.swift
+++ b/miataru/miataru/RouteStyle.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+struct RouteStyle {
+    /// Color for the already traversed portion of the route.
+    static var completed: Color = .blue
+    /// Color for the remaining portion of the route.
+    static var remaining: Color = .gray.opacity(0.4)
+}

--- a/miataru/miataru/views/Common/MapHelpers.swift
+++ b/miataru/miataru/views/Common/MapHelpers.swift
@@ -57,4 +57,44 @@ func relativeTimeString(
     let formatter = RelativeDateTimeFormatter()
     formatter.unitsStyle = unitsStyle
     return formatter.localizedString(for: date, relativeTo: now)
-} 
+}
+
+/// Splits a polyline at the given distance from its start and returns the
+/// traversed and remaining segments plus the interpolated coordinate.
+extension MKPolyline {
+    func split(at distance: CLLocationDistance) -> (MKPolyline, MKPolyline, CLLocationCoordinate2D)? {
+        guard pointCount > 1 else { return nil }
+
+        var coords = [CLLocationCoordinate2D](repeating: kCLLocationCoordinate2DInvalid, count: pointCount)
+        getCoordinates(&coords, range: NSRange(location: 0, length: pointCount))
+
+        var traveled: [CLLocationCoordinate2D] = [coords[0]]
+        var remaining: [CLLocationCoordinate2D] = coords
+        var accumulated: CLLocationDistance = 0
+
+        for i in 1..<coords.count {
+            let start = MKMapPoint(coords[i - 1])
+            let end = MKMapPoint(coords[i])
+            let segment = start.distance(to: end)
+
+            if accumulated + segment >= distance {
+                let ratio = segment > 0 ? (distance - accumulated) / segment : 0
+                let interp = CLLocationCoordinate2D(
+                    latitude: coords[i - 1].latitude + (coords[i].latitude - coords[i - 1].latitude) * ratio,
+                    longitude: coords[i - 1].longitude + (coords[i].longitude - coords[i - 1].longitude) * ratio
+                )
+                traveled.append(interp)
+                remaining[0] = interp
+                let traveledPolyline = MKPolyline(coordinates: traveled, count: traveled.count)
+                let remainingPolyline = MKPolyline(coordinates: remaining, count: remaining.count)
+                return (traveledPolyline, remainingPolyline, interp)
+            }
+
+            traveled.append(coords[i])
+            remaining.remove(at: 0)
+            accumulated += segment
+        }
+
+        return nil
+    }
+}

--- a/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceNavigationView.swift
+++ b/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceNavigationView.swift
@@ -147,9 +147,32 @@ struct iPhone_DeviceNavigationView: View {
                         .offset(y: 10)
                     }
                 }
-                if let polyline = route?.polyline {
-                    MapPolyline(polyline)
-                        .stroke(.blue, lineWidth: 4)
+                if let route = route {
+                    if let ts = deviceTimestamp {
+                        let elapsed = now.timeIntervalSince(ts)
+                        let expected = route.expectedTravelTime
+                        let progress = expected > 0 ? max(0, min(1, elapsed / expected)) : 0
+                        let splitDistance = route.distance * progress
+                        if let (done, todo, ghost) = route.polyline.split(at: splitDistance) {
+                            MapPolyline(done)
+                                .stroke(RouteStyle.completed, lineWidth: 4)
+                            MapPolyline(todo)
+                                .stroke(RouteStyle.remaining, lineWidth: 4)
+                            MapCircle(center: ghost, radius: 50)
+                                .foregroundStyle(RouteStyle.completed.opacity(0.2))
+                            Annotation("ghost", coordinate: ghost) {
+                                Image(systemName: "location.circle.fill")
+                                    .font(.system(size: 16))
+                                    .foregroundColor(RouteStyle.completed.opacity(0.5))
+                            }
+                        } else {
+                            MapPolyline(route.polyline)
+                                .stroke(RouteStyle.completed, lineWidth: 4)
+                        }
+                    } else {
+                        MapPolyline(route.polyline)
+                            .stroke(RouteStyle.completed, lineWidth: 4)
+                    }
                 }
             }
             .mapStyle(mapStyleFromSettings(settings.mapType))


### PR DESCRIPTION
## Summary
- Split navigation polylines to show completed vs remaining segments with configurable colors
- Display an estimated device location with a semi-transparent marker and circle on the route
- Consolidate polyline splitting helper into the shared MapHelpers file

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test -scheme miataru` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b00eefab448323ba1539e5a947d0df