### PR TITLE
Limit off-screen arrow segments to 10

### DIFF
--- a/miataru/miataru/views/Common/OffScreenDeviceArrow.swift
+++ b/miataru/miataru/views/Common/OffScreenDeviceArrow.swift
@@ -9,6 +9,7 @@
 
 import SwiftUI
 import MapKit
+import Foundation
 
 /// OffScreenDeviceArrow renders an arrow label at the screen edge pointing towards a device
 /// that is currently outside the visible map region.
@@ -34,6 +35,8 @@ struct OffScreenDeviceArrow: View {
     let deviceCoordinate: CLLocationCoordinate2D
     let mapRegion: MKCoordinateRegion
     let screenSize: CGSize
+    /// Distance between the map center and the device in kilometers. Supplied by the caller.
+    let distanceInKM: Double
     /// Whether the map is rotated. Kept for backwards compatibility; ignored for rendering while debugging.
     let isMapRotated: Bool
     /// Current map heading in degrees (clockwise). Used to rotate the device point around `screenCenter`.
@@ -62,6 +65,21 @@ struct OffScreenDeviceArrow: View {
     /// Spacing between multiple arrows on the same edge or at corners.
     private let arrowSpacing: CGFloat = 80
 
+    /// Segment length (in points) used to visualize distance.
+    private let segmentLength: CGFloat = 3
+    /// Spacing (in points) between arrow segments for clear separation.
+    private let segmentSpacing: CGFloat = 1
+    /// Maximum number of distance segments to display.
+    private let maxArrowSegments: Int = 10
+    /// Number of arrow segments representing the distance. Uses kilometers on
+    /// metric locales and miles on imperial locales to keep the visual
+    /// representation consistent with user settings.
+    private var arrowSegments: Int {
+        let distance = Locale.current.usesMetricSystem ?
+            distanceInKM : distanceInKM / 1.60934
+        return min(Int(distance), maxArrowSegments)
+    }
+
     // Computed property to determine the best text color for contrast
     private var textColor: Color {
         // Convert device color to UIColor to check brightness
@@ -87,10 +105,11 @@ struct OffScreenDeviceArrow: View {
             // Reference to avoid unused warning while we transition away from this flag
             let _ = isMapRotated
             VStack(spacing: 4) {
-                // Arrow pointing to device
-                Image(systemName: "arrow.up")
-                    .font(.system(size: 16, weight: .bold))
-                    .foregroundColor(deviceColor)
+                // Arrow pointing to device with distance-indicating segments
+                SegmentedArrow(segments: arrowSegments,
+                               color: deviceColor,
+                               segmentLength: segmentLength,
+                               segmentSpacing: segmentSpacing)
                     .rotationEffect(.degrees(arrowPosition.rotation))
                     .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
                 
@@ -452,6 +471,45 @@ struct OffScreenDeviceArrow: View {
     }
 }
 
+/// A simple vertically segmented arrow pointing up.
+struct SegmentedArrow: View {
+    let segments: Int
+    let color: Color
+    let segmentLength: CGFloat
+    let segmentSpacing: CGFloat
+
+    private let shaftWidth: CGFloat = 4
+    private let headHeight: CGFloat = 8
+    private let headWidth: CGFloat = 12
+
+    var body: some View {
+        VStack(spacing: segmentSpacing) {
+            ArrowHead()
+                .stroke(color, lineWidth: shaftWidth)
+                .frame(width: headWidth, height: headHeight)
+
+            ForEach(0..<segments) { _ in
+                Rectangle()
+                    .fill(color)
+                    .frame(width: shaftWidth, height: segmentLength)
+            }
+        }
+    }
+}
+
+/// Open arrowhead composed of two lines meeting at the tip.
+struct ArrowHead: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let tip = CGPoint(x: rect.midX, y: 0)
+        path.move(to: tip)
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.move(to: tip)
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        return path
+    }
+}
+
 enum Edge {
     case left, right, top, bottom
 }
@@ -476,6 +534,11 @@ private extension Comparable {
     }
 }
 
+// Allow integers to be used directly in SwiftUI `ForEach` without an explicit ID key path.
+extension Int: Identifiable {
+    public var id: Int { self }
+}
+
 #Preview {
     ZStack {
         Color.gray.opacity(0.3)
@@ -491,6 +554,7 @@ private extension Comparable {
                 span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
             ),
             screenSize: CGSize(width: 300, height: 400),
+            distanceInKM: 5,
             isMapRotated: false,
             mapHeading: 45,
             arrowIndex: 0,

--- a/miataru/miataru/views/Common/OffScreenDeviceArrow.swift
+++ b/miataru/miataru/views/Common/OffScreenDeviceArrow.swift
@@ -75,8 +75,13 @@ struct OffScreenDeviceArrow: View {
     /// metric locales and miles on imperial locales to keep the visual
     /// representation consistent with user settings.
     private var arrowSegments: Int {
-        let distance = Locale.current.usesMetricSystem ?
-            distanceInKM : distanceInKM / 1.60934
+        let usesMetric: Bool
+        if #available(iOS 16.0, *) {
+            usesMetric = Locale.current.measurementSystem == .metric
+        } else {
+            usesMetric = Locale.current.usesMetricSystem
+        }
+        let distance = usesMetric ? distanceInKM : distanceInKM / 1.60934
         return min(Int(distance), maxArrowSegments)
     }
 

--- a/miataru/miataru/views/iPad/Devices Views/iPad_DeviceMapView.swift
+++ b/miataru/miataru/views/iPad/Devices Views/iPad_DeviceMapView.swift
@@ -9,6 +9,7 @@
 
 import SwiftUI
 import MapKit
+import CoreLocation
 import MiataruAPIClient
 import Combine
 
@@ -62,6 +63,7 @@ struct iPad_DeviceMapView: View {
     private struct ArrowData {
         let device: KnownDevice
         let coordinate: CLLocationCoordinate2D
+        let distanceKM: Double
         let behavior: ArrowBehavior
         let onTap: () -> Void
     }
@@ -92,7 +94,10 @@ struct iPad_DeviceMapView: View {
                     }
                 }
             }
-            devicesByEdge[edge, default: []].append(ArrowData(device: device, coordinate: coordinate, behavior: .jumpToLocation, onTap: tap))
+            let deviceLocation = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+            let centerLocation = CLLocation(latitude: region.center.latitude, longitude: region.center.longitude)
+            let distanceKM = deviceLocation.distance(from: centerLocation) / 1000.0
+            devicesByEdge[edge, default: []].append(ArrowData(device: device, coordinate: coordinate, distanceKM: distanceKM, behavior: .jumpToLocation, onTap: tap))
         }
         
         // Other devices
@@ -112,7 +117,10 @@ struct iPad_DeviceMapView: View {
                                 onNavigateToDevice(otherDevice.DeviceID)
                             }
                         }
-                        devicesByEdge[edge, default: []].append(ArrowData(device: otherDevice, coordinate: coordinate, behavior: .navigateToDevice, onTap: tap))
+                        let deviceLocation = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+                        let centerLocation = CLLocation(latitude: region.center.latitude, longitude: region.center.longitude)
+                        let distanceKM = deviceLocation.distance(from: centerLocation) / 1000.0
+                        devicesByEdge[edge, default: []].append(ArrowData(device: otherDevice, coordinate: coordinate, distanceKM: distanceKM, behavior: .navigateToDevice, onTap: tap))
                     }
                 }
             }
@@ -199,6 +207,7 @@ struct iPad_DeviceMapView: View {
                                 deviceCoordinate: info.coordinate,
                                 mapRegion: region,
                                 screenSize: screenSize,
+                                distanceInKM: info.distanceKM,
                                 isMapRotated: false,
                                 mapHeading: currentMapCamera?.heading ?? 0,
                                 arrowIndex: index,

--- a/miataru/miataru/views/iPad/Groups Views/iPad_GroupMapView.swift
+++ b/miataru/miataru/views/iPad/Groups Views/iPad_GroupMapView.swift
@@ -9,6 +9,7 @@
 
 import SwiftUI
 import MapKit
+import CoreLocation
 import MiataruAPIClient
 import Combine
 
@@ -89,8 +90,8 @@ struct iPad_GroupMapView: View {
         return CLLocationCoordinate2D(latitude: 51.1657, longitude: 10.4515)
     }
     
-    private func computeDevicesByEdge(in region: MKCoordinateRegion) -> [Edge: [(device: KnownDevice, coordinate: CLLocationCoordinate2D, onTap: () -> Void)]] {
-        var devicesByEdge: [Edge: [(device: KnownDevice, coordinate: CLLocationCoordinate2D, onTap: () -> Void)]] = [:]
+    private func computeDevicesByEdge(in region: MKCoordinateRegion) -> [Edge: [(device: KnownDevice, coordinate: CLLocationCoordinate2D, distanceKM: Double, onTap: () -> Void)]] {
+        var devicesByEdge: [Edge: [(device: KnownDevice, coordinate: CLLocationCoordinate2D, distanceKM: Double, onTap: () -> Void)]] = [:]
         for deviceID in groupDeviceIDs {
             if let device = deviceStore.devices.first(where: { $0.DeviceID == deviceID }),
                let coordinate = deviceLocations[deviceID],
@@ -109,7 +110,10 @@ struct iPad_GroupMapView: View {
                         }
                     }
                 }
-                devicesByEdge[edge, default: []].append((device, coordinate, tap))
+                let deviceLocation = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+                let centerLocation = CLLocation(latitude: region.center.latitude, longitude: region.center.longitude)
+                let distanceKM = deviceLocation.distance(from: centerLocation) / 1000.0
+                devicesByEdge[edge, default: []].append((device, coordinate, distanceKM, tap))
             }
         }
         return devicesByEdge
@@ -131,6 +135,7 @@ struct iPad_GroupMapView: View {
                             deviceCoordinate: info.coordinate,
                             mapRegion: region,
                             screenSize: screenSize,
+                            distanceInKM: info.distanceKM,
                             isMapRotated: false,
                             mapHeading: currentMapCamera?.heading ?? 0,
                             arrowIndex: index,

--- a/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceMapView.swift
+++ b/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceMapView.swift
@@ -9,6 +9,7 @@
 
 import SwiftUI
 import MapKit
+import CoreLocation
 import MiataruAPIClient
 import Combine
 
@@ -61,6 +62,7 @@ struct iPhone_DeviceMapView: View {
     private struct ArrowData {
         let device: KnownDevice
         let coordinate: CLLocationCoordinate2D
+        let distanceKM: Double
         let behavior: ArrowBehavior
         let onTap: () -> Void
     }
@@ -91,7 +93,10 @@ struct iPhone_DeviceMapView: View {
                     }
                 }
             }
-            devicesByEdge[edge, default: []].append(ArrowData(device: device, coordinate: coordinate, behavior: .jumpToLocation, onTap: tap))
+            let deviceLocation = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+            let centerLocation = CLLocation(latitude: region.center.latitude, longitude: region.center.longitude)
+            let distanceKM = deviceLocation.distance(from: centerLocation) / 1000.0
+            devicesByEdge[edge, default: []].append(ArrowData(device: device, coordinate: coordinate, distanceKM: distanceKM, behavior: .jumpToLocation, onTap: tap))
         }
         
         // Other devices
@@ -111,7 +116,10 @@ struct iPhone_DeviceMapView: View {
                                 onNavigateToDevice(otherDevice.DeviceID)
                             }
                         }
-                        devicesByEdge[edge, default: []].append(ArrowData(device: otherDevice, coordinate: coordinate, behavior: .navigateToDevice, onTap: tap))
+                        let deviceLocation = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+                        let centerLocation = CLLocation(latitude: region.center.latitude, longitude: region.center.longitude)
+                        let distanceKM = deviceLocation.distance(from: centerLocation) / 1000.0
+                        devicesByEdge[edge, default: []].append(ArrowData(device: otherDevice, coordinate: coordinate, distanceKM: distanceKM, behavior: .navigateToDevice, onTap: tap))
                     }
                 }
             }
@@ -197,6 +205,7 @@ struct iPhone_DeviceMapView: View {
                                 deviceCoordinate: info.coordinate,
                                 mapRegion: region,
                                 screenSize: screenSize,
+                                distanceInKM: info.distanceKM,
                                 isMapRotated: false,
                                 mapHeading: currentMapCamera?.heading ?? 0,
                                 arrowIndex: index,

--- a/miataru/miataru/views/iPhone/Groups Views/iPhone_GroupMapView.swift
+++ b/miataru/miataru/views/iPhone/Groups Views/iPhone_GroupMapView.swift
@@ -9,6 +9,7 @@
 
 import SwiftUI
 import MapKit
+import CoreLocation
 import MiataruAPIClient
 import Combine
 
@@ -88,8 +89,8 @@ struct iPhone_GroupMapView: View {
         return CLLocationCoordinate2D(latitude: 51.1657, longitude: 10.4515)
     }
     
-    private func computeDevicesByEdge(in region: MKCoordinateRegion) -> [Edge: [(device: KnownDevice, coordinate: CLLocationCoordinate2D, onTap: () -> Void)]] {
-        var devicesByEdge: [Edge: [(device: KnownDevice, coordinate: CLLocationCoordinate2D, onTap: () -> Void)]] = [:]
+    private func computeDevicesByEdge(in region: MKCoordinateRegion) -> [Edge: [(device: KnownDevice, coordinate: CLLocationCoordinate2D, distanceKM: Double, onTap: () -> Void)]] {
+        var devicesByEdge: [Edge: [(device: KnownDevice, coordinate: CLLocationCoordinate2D, distanceKM: Double, onTap: () -> Void)]] = [:]
         for deviceID in groupDeviceIDs {
             if let device = deviceStore.devices.first(where: { $0.DeviceID == deviceID }),
                let coordinate = deviceLocations[deviceID],
@@ -108,7 +109,10 @@ struct iPhone_GroupMapView: View {
                         }
                     }
                 }
-                devicesByEdge[edge, default: []].append((device, coordinate, tap))
+                let deviceLocation = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+                let centerLocation = CLLocation(latitude: region.center.latitude, longitude: region.center.longitude)
+                let distanceKM = deviceLocation.distance(from: centerLocation) / 1000.0
+                devicesByEdge[edge, default: []].append((device, coordinate, distanceKM, tap))
             }
         }
         return devicesByEdge
@@ -130,6 +134,7 @@ struct iPhone_GroupMapView: View {
                             deviceCoordinate: info.coordinate,
                             mapRegion: region,
                             screenSize: screenSize,
+                            distanceInKM: info.distanceKM,
                             isMapRotated: false,
                             mapHeading: currentMapCamera?.heading ?? 0,
                             arrowIndex: index,


### PR DESCRIPTION
## Summary
- cap off-screen arrow's distance segments at ten to keep indicators compact

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `xcodebuild -list` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b1311981b88323a8171c7a7d0ad456