### PR TITLE
Hide tab bar on map interaction and add reveal control

### DIFF
--- a/miataru/miataru/views/Common/TabBarState.swift
+++ b/miataru/miataru/views/Common/TabBarState.swift
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2013-2025, Daniel Kirstenpfad, www.miataru.com
+ *
+ * TabBarState.swift
+ * miataru
+ *
+ * Created by OpenAI's assistant on 2024-07-09.
+ */
+
+import SwiftUI
+
+final class TabBarState: ObservableObject {
+    @Published var collapsed: Bool = false
+}
+

--- a/miataru/miataru/views/MiataruRootView.swift
+++ b/miataru/miataru/views/MiataruRootView.swift
@@ -11,16 +11,19 @@ import SwiftUI
 
 struct MiataruRootView: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @StateObject private var tabBarState = TabBarState()
 
     var body: some View {
         #if os(macOS)
         // Mac-spezifische View
         //MacRootView()
         iPhone_RootView() // for now
+            .environmentObject(tabBarState)
         #else
         if horizontalSizeClass == .compact {
             // iPhone-spezifische View
             iPhone_RootView()
+                .environmentObject(tabBarState)
         } else {
             // iPad-spezifische View
             iPad_RootView()

--- a/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceMapView.swift
+++ b/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceMapView.swift
@@ -57,6 +57,7 @@ struct iPhone_DeviceMapView: View {
     @State private var showNetworkErrorIcon = false // Show network error icon on network issues
     @State private var screenSize: CGSize = .zero // Track screen size for off-screen arrows
     @State private var isUpdating = false // Controls update button animation state
+    @EnvironmentObject var tabBarState: TabBarState
     
     // MARK: - Offscreen arrows support types/helpers
     private struct ArrowData {
@@ -222,6 +223,17 @@ struct iPhone_DeviceMapView: View {
             scaleBarView()
             // Compass in the top right corner
             compassView()
+            if tabBarState.collapsed {
+                Button {
+                    tabBarState.collapsed = false
+                } label: {
+                    Image(systemName: "menubar.rectangle")
+                        .padding(10)
+                        .background(.thinMaterial)
+                        .clipShape(Circle())
+                }
+                .padding()
+            }
         }
         .modifier(NavigationTitleModifier(deviceName: device?.DeviceName ?? "Unknown Device"))
         .navigationBarTitleDisplayMode(.inline)
@@ -308,6 +320,9 @@ struct iPhone_DeviceMapView: View {
             }
             // Always update region for off-screen arrows
             currentRegion = context.region
+            if (headingChanged || zoomChanged) && !tabBarState.collapsed {
+                tabBarState.collapsed = true
+            }
         }
         // Update 'now' every second for relative time display
         .onReceive(timeUpdateTimer) { input in

--- a/miataru/miataru/views/iPhone/iPhone_RootView.swift
+++ b/miataru/miataru/views/iPhone/iPhone_RootView.swift
@@ -10,30 +10,68 @@
 import SwiftUI
 
 struct iPhone_RootView: View {
+    @EnvironmentObject var tabBarState: TabBarState
+
     var body: some View {
-        TabView {
-            iPhone_DevicesView()
-                .tabItem {
-                    Label("devices", systemImage: "iphone.gen3.badge.location")
+        ZStack(alignment: .bottom) {
+            TabView {
+                iPhone_DevicesView()
+                    .tabItem {
+                        Label("devices", systemImage: "iphone.gen3.badge.location")
+                    }
+                iPhone_GroupsView()
+                    .tabItem {
+                        Label("groups", systemImage: "person.3")
+                    }
+                iPhone_MyDeviceQRCodeView()
+                    .tabItem {
+                        Label("qr", systemImage: "qrcode")
+                    }
+                iPhone_SettingsView()
+                    .tabItem {
+                        Label("settings", systemImage: "gear")
+                    }
+            }
+            if tabBarState.collapsed {
+                Button {
+                    tabBarState.collapsed = false
+                } label: {
+                    Image(systemName: "menubar.rectangle")
+                        .padding(10)
+                        .background(.thinMaterial)
+                        .clipShape(Circle())
                 }
-            iPhone_GroupsView()
-                .tabItem {
-                    Label("groups", systemImage: "person.3")
-                }
-            iPhone_MyDeviceQRCodeView()
-                .tabItem {
-                    Label("qr", systemImage: "qrcode")
-                }
-            iPhone_SettingsView()
-                .tabItem {
-                    Label("settings", systemImage: "gear")
-                }
+                .padding(.bottom, 8)
+            }
         }
         .environmentObject(DeviceGroupStore.shared)
+        .tabBarVisibility(tabBarState.collapsed)
+        .onAppear {
+            if #unavailable(iOS 16.0) {
+                UITabBar.appearance().isHidden = tabBarState.collapsed
+            }
+        }
+        .onChange(of: tabBarState.collapsed) { hidden in
+            if #unavailable(iOS 16.0) {
+                UITabBar.appearance().isHidden = hidden
+            }
+        }
         .adaptiveToolbarBackground()
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func tabBarVisibility(_ collapsed: Bool) -> some View {
+        if #available(iOS 16.0, *) {
+            self.toolbar(collapsed ? .hidden : .visible, for: .tabBar)
+        } else {
+            self
+        }
     }
 }
 
 #Preview {
     iPhone_RootView()
+        .environmentObject(TabBarState())
 }


### PR DESCRIPTION
## Summary
- Add `TabBarState` observable object to manage global tab bar visibility
- Hide or show the tab bar from `iPhone_RootView` with an overlay toggle button
- Collapse the tab bar on map interaction and provide a restore button within device map view

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fe5628948323810c3733f056e97c