### PR TITLE
Centralize application support directory handling

### DIFF
--- a/miataru/miataru/SettingsManagers/App Settings/Devices/DeviceLocationCacheStore.swift
+++ b/miataru/miataru/SettingsManagers/App Settings/Devices/DeviceLocationCacheStore.swift
@@ -88,15 +88,7 @@ class DeviceLocationCacheStore: ObservableObject {
     }
     
     private var fileURL: URL {
-        let fileManager = FileManager.default
-        let urls = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-        let appSupportURL = urls[0]
-        let bundleID = Bundle.main.bundleIdentifier ?? "DefaultApp"
-        let appDirectory = appSupportURL.appendingPathComponent(bundleID)
-        if !fileManager.fileExists(atPath: appDirectory.path) {
-            try? fileManager.createDirectory(at: appDirectory, withIntermediateDirectories: true, attributes: nil)
-        }
-        return appDirectory.appendingPathComponent(fileName)
+        AppDirectories.applicationSupportFile(named: fileName)
     }
     
     private init() {

--- a/miataru/miataru/SettingsManagers/App Settings/Devices/KnownDeviceStore.swift
+++ b/miataru/miataru/SettingsManagers/App Settings/Devices/KnownDeviceStore.swift
@@ -27,16 +27,7 @@ class KnownDeviceStore: ObservableObject {
     private var cancellables: [AnyCancellable] = []
 
     private var fileURL: URL {
-        let fileManager = FileManager.default
-        let urls = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-        let appSupportURL = urls[0]
-        let bundleID = Bundle.main.bundleIdentifier ?? "DefaultApp"
-        let appDirectory = appSupportURL.appendingPathComponent(bundleID)
-        // Verzeichnis anlegen, falls nicht vorhanden
-        if !fileManager.fileExists(atPath: appDirectory.path) {
-            try? fileManager.createDirectory(at: appDirectory, withIntermediateDirectories: true, attributes: nil)
-        }
-        return appDirectory.appendingPathComponent(fileName)
+        AppDirectories.applicationSupportFile(named: fileName)
     }
 
     // Make init private for singleton

--- a/miataru/miataru/SettingsManagers/App Settings/Groups/DeviceGroupStore.swift
+++ b/miataru/miataru/SettingsManagers/App Settings/Groups/DeviceGroupStore.swift
@@ -24,16 +24,7 @@ class DeviceGroupStore: ObservableObject {
     private var cancellables: [AnyCancellable] = []
 
     private var fileURL: URL {
-        let fileManager = FileManager.default
-        let urls = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-        let appSupportURL = urls[0]
-        let bundleID = Bundle.main.bundleIdentifier ?? "DefaultApp"
-        let appDirectory = appSupportURL.appendingPathComponent(bundleID)
-        // Verzeichnis anlegen, falls nicht vorhanden
-        if !fileManager.fileExists(atPath: appDirectory.path) {
-            try? fileManager.createDirectory(at: appDirectory, withIntermediateDirectories: true, attributes: nil)
-        }
-        return appDirectory.appendingPathComponent(fileName)
+        AppDirectories.applicationSupportFile(named: fileName)
     }
 
     // Make init private for singleton

--- a/miataru/miataru/SettingsManagers/AppDirectories.swift
+++ b/miataru/miataru/SettingsManagers/AppDirectories.swift
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2013-2025, Daniel Kirstenpfad, www.miataru.com
+ *
+ * AppDirectories.swift
+ * miataru
+ *
+ * Created by Daniel Kirstenpfad on 20.06.25.
+ */
+
+import Foundation
+
+/// Helper methods for dealing with filesystem locations specific to the app.
+///
+/// Currently this type exposes a convenience method for creating paths inside the
+/// app's "Application Support" directory.  Centralizing the logic ensures that
+/// every component writes to the same location and the directory gets created when needed.
+enum AppDirectories {
+    /// Returns a file URL inside the application's Application Support folder, creating the folder if needed.
+    /// - Parameter fileName: The name of the file.
+    /// - Returns: The full URL to the file within the application's support directory.
+    static func applicationSupportFile(named fileName: String) -> URL {
+        let fileManager = FileManager.default
+
+        // Base location for all Application Support files.
+        let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+
+        // Use the bundle identifier to create an app-specific subdirectory so our
+        // files don't collide with those from other apps.
+        let bundleID = Bundle.main.bundleIdentifier ?? "DefaultApp"
+        let appDirectory = appSupportURL.appendingPathComponent(bundleID)
+
+        // Create the directory if it doesn't already exist.
+        if !fileManager.fileExists(atPath: appDirectory.path) {
+            try? fileManager.createDirectory(at: appDirectory, withIntermediateDirectories: true, attributes: nil)
+        }
+
+        // Append the desired file name to obtain the final file URL.
+        return appDirectory.appendingPathComponent(fileName)
+    }
+}


### PR DESCRIPTION
## Summary
- add `AppDirectories` helper to compute paths inside Application Support
- refactor device, group, and location cache stores to use the new helper
- expand inline comments in `AppDirectories` for clarity

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bef49bdd708323b2f91b8da8b3827f