### PR TITLE
Annotate LocationManager with MainActor

### DIFF
--- a/miataru/miataru/LocationManagers/LocationManager.swift
+++ b/miataru/miataru/LocationManagers/LocationManager.swift
@@ -15,6 +15,7 @@ import UIKit
 import Network
 
 /// LocationManager handles high-accuracy foreground tracking and significant-change background tracking.
+@MainActor // Confine all access to the main thread for UI-safe, thread-safe updates without extra DispatchQueue.main hops.
 final class LocationManager: NSObject, ObservableObject {
     static let shared = LocationManager()
     
@@ -98,7 +99,6 @@ final class LocationManager: NSObject, ObservableObject {
     // MARK: - Settings Observer
     private func observeSettings() {
         settings.$trackAndReportLocation
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] shouldTrack in
                 guard let self else { return }
                 if shouldTrack {
@@ -112,7 +112,6 @@ final class LocationManager: NSObject, ObservableObject {
     
     private func observeActivityType() {
         settings.$locationActivityType
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] newValue in
                 guard let self = self else { return }
                 self.locationManager.activityType = Self.activityTypeFrom(newValue)


### PR DESCRIPTION
## Summary
- ensure LocationManager runs on the main actor for UI-safe updates
- drop redundant DispatchQueue.main calls in settings and activity observers
- document why the class is isolated on the main actor

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme miataru -project miataru/miataru.xcodeproj test` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68bef4e340488323a0bb0f15a6eff940