### PR TITLE
Remove didSet triggers from data models

### DIFF
--- a/miataru/miataru/SettingsManagers/App Settings/Devices/KnownDevice.swift
+++ b/miataru/miataru/SettingsManagers/App Settings/Devices/KnownDevice.swift
@@ -14,31 +14,12 @@ import MapKit
 
 @objc(KnownDevice)
 class KnownDevice: NSObject, ObservableObject, NSCoding, NSSecureCoding, Identifiable {
-    @Published @objc var DeviceName: String {
-        didSet {
-            objectWillChange.send()
-        }
-    }
-    @Published @objc var DeviceID: String {
-        didSet {
-            objectWillChange.send()
-        }
-    }
-    @Published @objc var DeviceIsInGroup: Bool = false {
-        didSet {
-            objectWillChange.send()
-        }
-    }
-    @Published @objc var KnownDevicesTablePosition: Int = 0 {
-        didSet {
-            objectWillChange.send()
-        }
-    }
-    @Published @objc var DeviceColor: UIColor? {
-        didSet {
-            objectWillChange.send()
-        }
-    }
+    // @Published properties automatically notify observers when mutated
+    @Published @objc var DeviceName: String
+    @Published @objc var DeviceID: String
+    @Published @objc var DeviceIsInGroup: Bool = false
+    @Published @objc var KnownDevicesTablePosition: Int = 0
+    @Published @objc var DeviceColor: UIColor?
     
     var id: String { DeviceID }
     

--- a/miataru/miataru/SettingsManagers/App Settings/Groups/DeviceGroup.swift
+++ b/miataru/miataru/SettingsManagers/App Settings/Groups/DeviceGroup.swift
@@ -13,21 +13,10 @@ import Combine
 
 @objc(DeviceGroup)
 class DeviceGroup: NSObject, ObservableObject, NSCoding, NSSecureCoding, Identifiable {
-    @Published @objc var groupName: String {
-        didSet {
-            objectWillChange.send()
-        }
-    }
-    @Published @objc var deviceIDs: Set<String> = [] {
-        didSet {
-            objectWillChange.send()
-        }
-    }
-    @Published @objc var groupPosition: Int = 0 {
-        didSet {
-            objectWillChange.send()
-        }
-    }
+    // Using @Published ensures observers get change notifications without manual didSet
+    @Published @objc var groupName: String
+    @Published @objc var deviceIDs: Set<String> = []
+    @Published @objc var groupPosition: Int = 0
     
     var id: String { groupName }
     


### PR DESCRIPTION
## Summary
- simplify `DeviceGroup` model by removing manual `objectWillChange` notifications
- streamline `KnownDevice` model with implicit `@Published` updates
- document that `@Published` handles change propagation in both models

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bef6b10e208323928dfcb21a620a55