### PR TITLE
Add configurable shimmering animation for map route polylines

### DIFF
--- a/miataru/miataru/views/Common/Map/ShimmeringRoutePolyline.swift
+++ b/miataru/miataru/views/Common/Map/ShimmeringRoutePolyline.swift
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2013-2025, Daniel Kirstenpfad, www.miataru.com
+ *
+ * ShimmeringRoutePolyline.swift
+ * miataru
+ *
+ * Created by Codex on 06.02.26.
+ */
+
+import SwiftUI
+import MapKit
+
+/// Animation direction for the route shimmer.
+enum RouteShimmerDirection {
+    /// Animate from the polyline start point to its end point.
+    case forward
+    /// Animate from the polyline end point back to its start point.
+    case backward
+
+    var phaseSign: CGFloat {
+        switch self {
+        case .forward: return -1
+        case .backward: return 1
+        }
+    }
+}
+
+/// Styling and behavior options for an animated route shimmer.
+struct RouteShimmerConfiguration {
+    var isLooping: Bool = true
+    var showsAnimation: Bool = true
+    var direction: RouteShimmerDirection = .forward
+    var cycleDuration: Double = 1.6
+    var baseLineWidth: CGFloat = 4
+    var shimmerLineWidth: CGFloat = 6
+    var dashLength: CGFloat = 22
+    var dashGap: CGFloat = 30
+    var baseColor: Color = RouteStyle.withoutRemaining
+    var shimmerColor: Color = .white
+    var shimmerOpacity: Double = 0.9
+
+    var cycleLength: CGFloat {
+        max(1, dashLength + dashGap)
+    }
+}
+
+/// MapContent component that renders a route polyline with an optional directional shimmer overlay.
+struct ShimmeringRoutePolyline: MapContent {
+    @Environment(\.animationsAllowed) private var animationsAllowed
+
+    let polyline: MKPolyline
+    let configuration: RouteShimmerConfiguration
+    let progress: CGFloat
+
+    private var effectiveProgress: CGFloat {
+        if configuration.isLooping {
+            progress.truncatingRemainder(dividingBy: 1)
+        } else {
+            min(1, max(0, progress))
+        }
+    }
+
+    private var dashPhase: CGFloat {
+        configuration.direction.phaseSign * effectiveProgress * configuration.cycleLength
+    }
+
+    var body: some MapContent {
+        MapPolyline(polyline)
+            .stroke(configuration.baseColor, lineWidth: configuration.baseLineWidth)
+
+        if configuration.showsAnimation && animationsAllowed {
+            MapPolyline(polyline)
+                .stroke(
+                    LinearGradient(
+                        colors: [
+                            configuration.shimmerColor.opacity(0),
+                            configuration.shimmerColor.opacity(configuration.shimmerOpacity),
+                            configuration.shimmerColor.opacity(0)
+                        ],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    ),
+                    style: StrokeStyle(
+                        lineWidth: configuration.shimmerLineWidth,
+                        lineCap: .round,
+                        lineJoin: .round,
+                        dash: [configuration.dashLength, configuration.dashGap],
+                        dashPhase: dashPhase
+                    )
+                )
+        }
+    }
+}

--- a/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceNavigationView.swift
+++ b/miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceNavigationView.swift
@@ -64,6 +64,7 @@ struct iPhone_DeviceNavigationView: View {
     @State private var isFollowAutoZoomEnabled: Bool = true
     @State private var currentMapHeadingDegrees: Double = 0
     @State private var shouldPerformInitialNavigationZoom: Bool = false
+    @State private var routeShimmerProgress: CGFloat = 0
     @StateObject private var errorOverlayManager = ErrorOverlayManager()
     @StateObject private var infoOverlayManager = InfoOverlayManager()
     @ObservedObject private var routeCounter = RouteRequestCounter.shared
@@ -124,6 +125,27 @@ struct iPhone_DeviceNavigationView: View {
     private let navigationStraightSoundName = "nav_straight"
     private let leftNavigationHapticInterval: TimeInterval = 0.2
     private let rightNavigationHapticInterval: TimeInterval = 0.12
+    private var routeShimmerConfiguration: RouteShimmerConfiguration {
+        RouteShimmerConfiguration(
+            isLooping: true,
+            showsAnimation: true,
+            direction: isRouteReversed ? .forward : .backward,
+            cycleDuration: 1.4,
+            baseLineWidth: 4,
+            shimmerLineWidth: 6,
+            dashLength: 24,
+            dashGap: 26,
+            baseColor: RouteStyle.withoutRemaining,
+            shimmerColor: .white,
+            shimmerOpacity: 0.92
+        )
+    }
+
+    private func shimmerConfig(baseColor: Color) -> RouteShimmerConfiguration {
+        var configuration = routeShimmerConfiguration
+        configuration.baseColor = baseColor
+        return configuration
+    }
 
     var body: some View {
         VStack {
@@ -230,24 +252,36 @@ struct iPhone_DeviceNavigationView: View {
                         isRouteReversed: isRouteReversed
                     ) {
                         if progress <= minimumProgressToShowGhost {
-                            MapPolyline(route.polyline)
-                                .stroke(RouteStyle.remaining, lineWidth: 4)
+                            ShimmeringRoutePolyline(
+                                polyline: route.polyline,
+                                configuration: shimmerConfig(baseColor: RouteStyle.remaining),
+                                progress: routeShimmerProgress
+                            )
                             if isMutualNavigation {
                                 MapPolyline(route.polyline)
                                     .stroke(RouteStyle.mutualNavigation, lineWidth: 2.5)
                             }
                         } else if progress >= 1 {
-                            MapPolyline(route.polyline)
-                                .stroke(RouteStyle.completed, lineWidth: 4)
+                            ShimmeringRoutePolyline(
+                                polyline: route.polyline,
+                                configuration: shimmerConfig(baseColor: RouteStyle.completed),
+                                progress: routeShimmerProgress
+                            )
                             if isMutualNavigation {
                                 MapPolyline(route.polyline)
                                     .stroke(RouteStyle.mutualNavigation, lineWidth: 2.5)
                             }
                         } else {
-                            MapPolyline(done)
-                                .stroke(RouteStyle.completed, lineWidth: 4)
-                            MapPolyline(todo)
-                                .stroke(RouteStyle.remaining, lineWidth: 4)
+                            ShimmeringRoutePolyline(
+                                polyline: done,
+                                configuration: shimmerConfig(baseColor: RouteStyle.completed),
+                                progress: routeShimmerProgress
+                            )
+                            ShimmeringRoutePolyline(
+                                polyline: todo,
+                                configuration: shimmerConfig(baseColor: RouteStyle.remaining),
+                                progress: routeShimmerProgress
+                            )
                             if isMutualNavigation {
                                 MapPolyline(done)
                                     .stroke(RouteStyle.mutualNavigation, lineWidth: 2.5)
@@ -275,16 +309,22 @@ struct iPhone_DeviceNavigationView: View {
                             }
                         }
                     } else {
-                        MapPolyline(route.polyline)
-                            .stroke(RouteStyle.withoutRemaining, lineWidth: 4)
+                        ShimmeringRoutePolyline(
+                            polyline: route.polyline,
+                            configuration: routeShimmerConfiguration,
+                            progress: routeShimmerProgress
+                        )
                         if isMutualNavigation {
                             MapPolyline(route.polyline)
                                 .stroke(RouteStyle.mutualNavigation, lineWidth: 2.5)
                         }
                     }
                 } else {
-                    MapPolyline(route.polyline)
-                        .stroke(RouteStyle.withoutRemaining, lineWidth: 4)
+                    ShimmeringRoutePolyline(
+                        polyline: route.polyline,
+                        configuration: routeShimmerConfiguration,
+                        progress: routeShimmerProgress
+                    )
                     if isMutualNavigation {
                         MapPolyline(route.polyline)
                             .stroke(RouteStyle.mutualNavigation, lineWidth: 2.5)
@@ -348,6 +388,10 @@ struct iPhone_DeviceNavigationView: View {
                 mutualNavigationDetector.startMonitoring(targetDeviceId: device.DeviceID, serverURL: settings.miataruServerURL)
                 // Initialize mutual navigation state
                 isMutualNavigation = mutualNavigationDetector.isMutualNavigation
+                routeShimmerProgress = 0
+                withAnimation(.linear(duration: routeShimmerConfiguration.cycleDuration).repeatForever(autoreverses: false)) {
+                    routeShimmerProgress = 1
+                }
             }
             .onReceive(locationManager.$currentLocation) { _ in
                 updateCoordinates()
@@ -1691,5 +1735,4 @@ extension iPhone_DeviceNavigationView {
     
     
 }
-
 


### PR DESCRIPTION
### Motivation
- Improve route visualization by adding a directional, loopable shimmer along map polylines so the route direction and progress are clearer to users.
- Make shimmer appearance and behavior configurable (direction, loop, colors, widths, dash pattern, cycle duration) so it can be adjusted per UI needs.

### Description
- Added a new reusable MapContent component `ShimmeringRoutePolyline` with `RouteShimmerConfiguration` and `RouteShimmerDirection` to control shimmer direction, loop behavior, dash pattern, colors, widths and cycle duration (file: `miataru/miataru/views/Common/Map/ShimmeringRoutePolyline.swift`).
- Integrated the shimmering component into `iPhone_DeviceNavigationView` replacing static `MapPolyline` strokes for full route and done/todo segments, and exposed `routeShimmerProgress` and `routeShimmerConfiguration` to drive the animation (file: `miataru/miataru/views/iPhone/Devices Views/iPhone_DeviceNavigationView.swift`).
- Added a small helper `shimmerConfig(baseColor:)` so base color can be overridden per-segment, and wired a continuous `withAnimation(...repeatForever...)` progress animation on view appear; shimmer direction follows the route reversal state (`isRouteReversed`).
- The shimmer respects the global `animationsAllowed` environment key so it automatically disables in low-power/inactive contexts.

### Testing
- Ran `swift --version` to verify Swift toolchain presence; command succeeded.
- Attempted to run `xcodebuild -project miataru/miataru.xcodeproj -list` but `xcodebuild` is not available in this Linux environment, so full Xcode build validation could not be performed.
- Verified file-level modifications and that the new component compiles conceptually by static inspection; no automated unit/UI tests were available/executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985ba1eb3ac8323ad71907abd12fa39)